### PR TITLE
Support refresh interval option

### DIFF
--- a/custom_components/donetick/__init__.py
+++ b/custom_components/donetick/__init__.py
@@ -96,6 +96,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                   DOMAIN, SERVICE_UPDATE_TASK, DOMAIN, SERVICE_DELETE_TASK)
     
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.add_update_listener(async_reload_entry)
     
     return True
 
@@ -299,3 +301,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                           DOMAIN, SERVICE_UPDATE_TASK, DOMAIN, SERVICE_DELETE_TASK)
     
     return unload_ok
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload config entry."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/donetick/config_flow.py
+++ b/custom_components/donetick/config_flow.py
@@ -3,16 +3,39 @@ from typing import Any
 import logging
 import voluptuous as vol
 import aiohttp
+from datetime import timedelta
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_CREATE_UNIFIED_LIST, CONF_CREATE_ASSIGNEE_LISTS
+from homeassistant.helpers.selector import (
+    DurationSelector,
+    DurationSelectorConfig,
+)
+
+from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_CREATE_UNIFIED_LIST, CONF_CREATE_ASSIGNEE_LISTS, CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL
 from .api import DonetickApiClient
 
 _LOGGER = logging.getLogger(__name__)
+
+def _seconds_to_time_config(total_seconds: int):
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return {
+        "hours": hours,
+        "minutes": minutes,
+        "seconds": seconds,
+    }
+
+def _config_to_seconds(config: dict[str, int]):
+    return timedelta(
+        hours=config["hours"],
+        minutes=config["minutes"],
+        seconds=config["seconds"],
+    ).total_seconds()
 
 class DonetickConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Donetick."""
@@ -62,11 +85,15 @@ class DonetickConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the options step."""
         if user_input is not None:
+            refresh_interval = DEFAULT_REFRESH_INTERVAL
+            if (refresh_interval_input := user_input.get(CONF_REFRESH_INTERVAL)) is not None:
+                refresh_interval = _config_to_seconds(refresh_interval_input)
             final_data = {
                 **self._server_data,
                 CONF_SHOW_DUE_IN: user_input.get(CONF_SHOW_DUE_IN, 7),
                 CONF_CREATE_UNIFIED_LIST: user_input.get(CONF_CREATE_UNIFIED_LIST, True),
                 CONF_CREATE_ASSIGNEE_LISTS: user_input.get(CONF_CREATE_ASSIGNEE_LISTS, False),
+                CONF_REFRESH_INTERVAL: refresh_interval
             }
             
             return self.async_create_entry(
@@ -80,6 +107,9 @@ class DonetickConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_SHOW_DUE_IN, default=7): vol.Coerce(int),
                 vol.Optional(CONF_CREATE_UNIFIED_LIST, default=True): bool,
                 vol.Optional(CONF_CREATE_ASSIGNEE_LISTS, default=False): bool,
+                vol.Optional(CONF_REFRESH_INTERVAL, default=_seconds_to_time_config(DEFAULT_REFRESH_INTERVAL)): DurationSelector(
+                    DurationSelectorConfig(enable_day=False, allow_negative=False)
+                ),
             }),
         )
 
@@ -94,21 +124,35 @@ class DonetickOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self.entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
-            return self.async_create_entry(
-                title="",
-                data={
-                    CONF_SHOW_DUE_IN: user_input.get(CONF_SHOW_DUE_IN, 7),
-                    CONF_CREATE_UNIFIED_LIST: user_input.get(CONF_CREATE_UNIFIED_LIST, True),
-                    CONF_CREATE_ASSIGNEE_LISTS: user_input.get(CONF_CREATE_ASSIGNEE_LISTS, False),
-                },
+            refresh_interval = DEFAULT_REFRESH_INTERVAL
+            if (refresh_interval_input := user_input.get(CONF_REFRESH_INTERVAL)) is not None:
+                refresh_interval = _config_to_seconds(refresh_interval_input)
+            data = {
+                CONF_URL: self.entry.data.get(CONF_URL),
+                CONF_TOKEN: self.entry.data.get(CONF_TOKEN),
+                CONF_SHOW_DUE_IN: user_input.get(CONF_SHOW_DUE_IN, 7),
+                CONF_CREATE_UNIFIED_LIST: user_input.get(CONF_CREATE_UNIFIED_LIST, True),
+                CONF_CREATE_ASSIGNEE_LISTS: user_input.get(CONF_CREATE_ASSIGNEE_LISTS, False),
+                CONF_REFRESH_INTERVAL: refresh_interval
+            }
+
+            # Workaround to being able to use the same parameters in both config and options flow. 
+            # https://community.home-assistant.io/t/configflowhandler-and-optionsflowhandler-managing-the-same-parameter/365582
+            self.hass.config_entries.async_update_entry(
+                self.entry, data=data, options=self.entry.options
             )
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(self.entry.entry_id)
+            )
+            self.async_abort(reason="configuration updated")
+            return self.async_create_entry(title="", data={})
 
         # No additional data needed for display
 
@@ -117,15 +161,19 @@ class DonetickOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema({
                 vol.Optional(
                     CONF_SHOW_DUE_IN,
-                    default=self.config_entry.options.get(CONF_SHOW_DUE_IN, 7)
+                    default=self.entry.data.get(CONF_SHOW_DUE_IN, 7)
                 ): vol.Coerce(int),
                 vol.Optional(
                     CONF_CREATE_UNIFIED_LIST,
-                    default=self.config_entry.options.get(CONF_CREATE_UNIFIED_LIST, True)
+                    default=self.entry.data.get(CONF_CREATE_UNIFIED_LIST, True)
                 ): bool,
                 vol.Optional(
                     CONF_CREATE_ASSIGNEE_LISTS,
-                    default=self.config_entry.options.get(CONF_CREATE_ASSIGNEE_LISTS, False)
+                    default=self.entry.data.get(CONF_CREATE_ASSIGNEE_LISTS, False)
                 ): bool,
+                vol.Optional(
+                    CONF_REFRESH_INTERVAL, 
+                    default=_seconds_to_time_config(self.entry.data.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL))
+                ): DurationSelector(DurationSelectorConfig(enable_day=False, allow_negative=False))
             }),
         )

--- a/custom_components/donetick/const.py
+++ b/custom_components/donetick/const.py
@@ -7,5 +7,8 @@ CONF_TOKEN = "token"
 CONF_SHOW_DUE_IN = "show_due_in"
 CONF_CREATE_UNIFIED_LIST = "create_unified_list"
 CONF_CREATE_ASSIGNEE_LISTS = "create_assignee_lists"
+CONF_REFRESH_INTERVAL = "refresh_interval"
+
+DEFAULT_REFRESH_INTERVAL = 900 # seconds - 15 minutes
 
 API_TIMEOUT = 10  # seconds

--- a/custom_components/donetick/todo.py
+++ b/custom_components/donetick/todo.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_CREATE_UNIFIED_LIST, CONF_CREATE_ASSIGNEE_LISTS
+from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_CREATE_UNIFIED_LIST, CONF_CREATE_ASSIGNEE_LISTS, CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL
 from .api import DonetickApiClient
 from .model import DonetickTask, DonetickMember
 
@@ -37,12 +37,13 @@ async def async_setup_entry(
         session,
     )
 
+    refresh_interval_seconds = config_entry.data.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL)
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name="donetick_todo",
         update_method=client.async_get_tasks,
-        update_interval=timedelta(minutes=15),
+        update_interval=timedelta(seconds=refresh_interval_seconds),
     )
 
     await coordinator.async_config_entry_first_refresh()


### PR DESCRIPTION
I have added a configuration option for setting the scan interval of the sensors.
This would fix issue #11  

Besides that the actual options flow didn't seem to be working in it's original state due to some quirks in how home assistant handles using the same fields in both config and options flows