### PR TITLE
Add option to define todo lists per label

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Home Assistant integration for Donetick that provides support for managing tod
 ## Features
 
 ### 📋 Todo Lists
-- **Multiple Todo Lists**: "All Tasks" view and individual assignee-specific lists
+- **Multiple Todo Lists**: "All Tasks" view, individual assignee-specific lists and label-specific lists
 - **Task Management**: Create, update, delete, and complete tasks
 - **Task attributes**: Task descriptions, due dates can be managed in Home Assistant
 
@@ -53,4 +53,5 @@ Configure via **Settings** → **Devices & Services** → **Add Integration** �
 **Optional:**
 - **Show Due In**: Days ahead to display upcoming tasks (default: 7)
 - **Create Unified List**: Enable "All Tasks" todo list (default: true)  
-- **Create Assignee Lists**: Individual todo lists per user (default: false) 
+- **Create Assignee Lists**: Individual todo lists per user (default: false)
+- **Create Label Lists**: Individual todo lists per label (default: false) 

--- a/custom_components/donetick/config_flow.py
+++ b/custom_components/donetick/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.selector import (
     DurationSelectorConfig,
 )
 
-from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_CREATE_UNIFIED_LIST, CONF_CREATE_ASSIGNEE_LISTS, CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL
+from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_CREATE_UNIFIED_LIST, CONF_CREATE_ASSIGNEE_LISTS, CONF_CREATE_LABEL_LISTS, CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL
 from .api import DonetickApiClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -93,6 +93,7 @@ class DonetickConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_SHOW_DUE_IN: user_input.get(CONF_SHOW_DUE_IN, 7),
                 CONF_CREATE_UNIFIED_LIST: user_input.get(CONF_CREATE_UNIFIED_LIST, True),
                 CONF_CREATE_ASSIGNEE_LISTS: user_input.get(CONF_CREATE_ASSIGNEE_LISTS, False),
+                CONF_CREATE_LABEL_LISTS: user_input.get(CONF_CREATE_LABEL_LISTS, False),
                 CONF_REFRESH_INTERVAL: refresh_interval
             }
             
@@ -107,6 +108,7 @@ class DonetickConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_SHOW_DUE_IN, default=7): vol.Coerce(int),
                 vol.Optional(CONF_CREATE_UNIFIED_LIST, default=True): bool,
                 vol.Optional(CONF_CREATE_ASSIGNEE_LISTS, default=False): bool,
+                vol.Optional(CONF_CREATE_LABEL_LISTS, default=False): bool,
                 vol.Optional(CONF_REFRESH_INTERVAL, default=_seconds_to_time_config(DEFAULT_REFRESH_INTERVAL)): DurationSelector(
                     DurationSelectorConfig(enable_day=False, allow_negative=False)
                 ),
@@ -140,6 +142,7 @@ class DonetickOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_SHOW_DUE_IN: user_input.get(CONF_SHOW_DUE_IN, 7),
                 CONF_CREATE_UNIFIED_LIST: user_input.get(CONF_CREATE_UNIFIED_LIST, True),
                 CONF_CREATE_ASSIGNEE_LISTS: user_input.get(CONF_CREATE_ASSIGNEE_LISTS, False),
+                CONF_CREATE_LABEL_LISTS: user_input.get(CONF_CREATE_LABEL_LISTS, False),
                 CONF_REFRESH_INTERVAL: refresh_interval
             }
 
@@ -170,6 +173,10 @@ class DonetickOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_CREATE_ASSIGNEE_LISTS,
                     default=self.entry.data.get(CONF_CREATE_ASSIGNEE_LISTS, False)
+                ): bool,
+                vol.Optional(
+                    CONF_CREATE_LABEL_LISTS,
+                    default=self.entry.data.get(CONF_CREATE_LABEL_LISTS, False)
                 ): bool,
                 vol.Optional(
                     CONF_REFRESH_INTERVAL, 

--- a/custom_components/donetick/const.py
+++ b/custom_components/donetick/const.py
@@ -7,6 +7,7 @@ CONF_TOKEN = "token"
 CONF_SHOW_DUE_IN = "show_due_in"
 CONF_CREATE_UNIFIED_LIST = "create_unified_list"
 CONF_CREATE_ASSIGNEE_LISTS = "create_assignee_lists"
+CONF_CREATE_LABEL_LISTS = "create_label_lists"
 CONF_REFRESH_INTERVAL = "refresh_interval"
 
 DEFAULT_REFRESH_INTERVAL = 900 # seconds - 15 minutes

--- a/custom_components/donetick/model.py
+++ b/custom_components/donetick/model.py
@@ -57,6 +57,22 @@ class DonetickAssignee:
     user_id: int
 
 @dataclass
+class DonetickLabel:
+    """Donetick label model."""
+    id: Optional[int]
+    name: str
+    color: Optional[str] = None
+
+    @classmethod
+    def from_json(cls, data: dict) -> "DonetickLabel":
+        return cls(
+            id=data.get("id"),
+            name=data.get("name", ""),
+            color=data.get("color"),
+        )
+
+
+@dataclass
 class DonetickTask:
     """Donetick task model."""
     id: int
@@ -71,6 +87,9 @@ class DonetickTask:
     frequency_metadata: str
     assigned_to: Optional[int] = None
     description: Optional[str] = None
+    labels_v2: Optional[List[DonetickLabel]] = None
+    label_names: Optional[List[str]] = None
+    label_names_normalized: Optional[List[str]] = None
     
     @classmethod
     def from_json(cls, data: dict) -> "DonetickTask":
@@ -80,6 +99,14 @@ class DonetickTask:
         if data.get("assignedTo"):
             if isinstance(data["assignedTo"], int):
                 assigned_to = data["assignedTo"]
+        labels_v2: Optional[List[DonetickLabel]] = None
+        label_names: List[str] = []
+        if isinstance(data.get("labelsV2"), list):
+            labels_v2 = [DonetickLabel.from_json(label) for label in data["labelsV2"]]
+            label_names = [label.name for label in labels_v2 if label.name]
+        elif data.get("labels"):
+            label_names = [label.strip() for label in data["labels"].split(",") if label.strip()]
+        label_names_normalized = [name.lower() for name in label_names]
           
         return cls(
             id=data["id"],
@@ -93,7 +120,10 @@ class DonetickTask:
             frequency=data["frequency"],
             frequency_metadata=data["frequencyMetadata"],
             assigned_to=assigned_to,
-            description=data.get("description")
+            description=data.get("description"),
+            labels_v2=labels_v2,
+            label_names=label_names or None,
+            label_names_normalized=label_names_normalized or None,
         )
     
     @classmethod

--- a/custom_components/donetick/strings.json
+++ b/custom_components/donetick/strings.json
@@ -30,6 +30,10 @@
                     "create_assignee_lists": {
                         "name": "Create individual task lists per person",
                         "description": "Create separate todo lists for each person assigned to tasks"
+                    },
+                    "create_label_lists": {
+                        "name": "Create per-label task lists",
+                        "description": "Create separate todo lists for each Donetick label"
                     }
                 }
             }
@@ -52,6 +56,10 @@
                     "create_assignee_lists": {
                         "name": "Create individual task lists per person",
                         "description": "Create separate todo lists for each person assigned to tasks"
+                    },
+                    "create_label_lists": {
+                        "name": "Create per-label task lists",
+                        "description": "Create separate todo lists for each Donetick label"
                     }
                 }
             }

--- a/custom_components/donetick/translations/en.json
+++ b/custom_components/donetick/translations/en.json
@@ -15,7 +15,8 @@
                 "data": {
                     "show_due_in": "Days ahead to show upcoming tasks",
                     "create_unified_list": "Create \"All Tasks\" list",
-                    "create_assignee_lists": "Create individual task lists per person"
+                    "create_assignee_lists": "Create individual task lists per person",
+                    "create_label_lists": "Create separate todo lists per label"
                 }
             }
         }
@@ -28,7 +29,8 @@
                 "data": {
                     "show_due_in": "Days ahead to show upcoming tasks",
                     "create_unified_list": "Create \"All Tasks\" list",
-                    "create_assignee_lists": "Create individual task lists per person"
+                    "create_assignee_lists": "Create individual task lists per person",
+                    "create_label_lists": "Create separate todo lists per label"
                 }
             }
         }


### PR DESCRIPTION
This is to address https://github.com/donetick/donetick/discussions/381
Allows (optionally) to define todo lists per donetick chore label in Home Assistant.
Means you can now display specific todo lists "filtered" on a label in specific part of home assistant dashboard or use advanced to do card such as Todo Swipe Card.