### PR TITLE
Fix sync days feature to work, add sync only calendar day

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,6 @@ Configure via **Settings** → **Devices & Services** → **Add Integration** �
 
 **Optional:**
 - **Show Due In**: Days ahead to display upcoming tasks (default: 7)
+- **Only Show Today**: Hide tasks until their calendar day begins (default: false)
 - **Create Unified List**: Enable "All Tasks" todo list (default: true)  
 - **Create Assignee Lists**: Individual todo lists per user (default: false) 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ Configure via **Settings** → **Devices & Services** → **Add Integration** �
 
 **Optional:**
 - **Show Due In**: Days ahead to display upcoming tasks (default: 7)
-- **Only Show Today**: Hide tasks until their calendar day begins (default: false)
+- **Show Today or Overdue**: Hide future-dated tasks until their calendar day begins (default: false)
 - **Create Unified List**: Enable "All Tasks" todo list (default: true)  
 - **Create Assignee Lists**: Individual todo lists per user (default: false) 

--- a/custom_components/donetick/__init__.py
+++ b/custom_components/donetick/__init__.py
@@ -6,7 +6,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN
+from .const import (
+    DOMAIN,
+    CONF_URL,
+    CONF_TOKEN,
+    CONF_SHOW_DUE_IN,
+    CONF_SHOW_ONLY_TODAY,
+)
 from .api import DonetickApiClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,7 +57,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = {
         CONF_URL: entry.data[CONF_URL],
         CONF_TOKEN: entry.data[CONF_TOKEN],
-        CONF_SHOW_DUE_IN: entry.data.get(CONF_SHOW_DUE_IN,7),
+        CONF_SHOW_DUE_IN: entry.data.get(CONF_SHOW_DUE_IN, 7),
+        CONF_SHOW_ONLY_TODAY: entry.data.get(CONF_SHOW_ONLY_TODAY, False),
     }
     
     # Register services before setting up platforms

--- a/custom_components/donetick/config_flow.py
+++ b/custom_components/donetick/config_flow.py
@@ -16,7 +16,17 @@ from homeassistant.helpers.selector import (
     DurationSelectorConfig,
 )
 
-from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_CREATE_UNIFIED_LIST, CONF_CREATE_ASSIGNEE_LISTS, CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL
+from .const import (
+    DOMAIN,
+    CONF_URL,
+    CONF_TOKEN,
+    CONF_SHOW_DUE_IN,
+    CONF_SHOW_ONLY_TODAY,
+    CONF_CREATE_UNIFIED_LIST,
+    CONF_CREATE_ASSIGNEE_LISTS,
+    CONF_REFRESH_INTERVAL,
+    DEFAULT_REFRESH_INTERVAL,
+)
 from .api import DonetickApiClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -91,6 +101,7 @@ class DonetickConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             final_data = {
                 **self._server_data,
                 CONF_SHOW_DUE_IN: user_input.get(CONF_SHOW_DUE_IN, 7),
+                CONF_SHOW_ONLY_TODAY: user_input.get(CONF_SHOW_ONLY_TODAY, False),
                 CONF_CREATE_UNIFIED_LIST: user_input.get(CONF_CREATE_UNIFIED_LIST, True),
                 CONF_CREATE_ASSIGNEE_LISTS: user_input.get(CONF_CREATE_ASSIGNEE_LISTS, False),
                 CONF_REFRESH_INTERVAL: refresh_interval
@@ -105,6 +116,7 @@ class DonetickConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="options",
             data_schema=vol.Schema({
                 vol.Optional(CONF_SHOW_DUE_IN, default=7): vol.Coerce(int),
+                vol.Optional(CONF_SHOW_ONLY_TODAY, default=False): bool,
                 vol.Optional(CONF_CREATE_UNIFIED_LIST, default=True): bool,
                 vol.Optional(CONF_CREATE_ASSIGNEE_LISTS, default=False): bool,
                 vol.Optional(CONF_REFRESH_INTERVAL, default=_seconds_to_time_config(DEFAULT_REFRESH_INTERVAL)): DurationSelector(
@@ -138,6 +150,7 @@ class DonetickOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_URL: self.entry.data.get(CONF_URL),
                 CONF_TOKEN: self.entry.data.get(CONF_TOKEN),
                 CONF_SHOW_DUE_IN: user_input.get(CONF_SHOW_DUE_IN, 7),
+                CONF_SHOW_ONLY_TODAY: user_input.get(CONF_SHOW_ONLY_TODAY, False),
                 CONF_CREATE_UNIFIED_LIST: user_input.get(CONF_CREATE_UNIFIED_LIST, True),
                 CONF_CREATE_ASSIGNEE_LISTS: user_input.get(CONF_CREATE_ASSIGNEE_LISTS, False),
                 CONF_REFRESH_INTERVAL: refresh_interval
@@ -163,6 +176,10 @@ class DonetickOptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_SHOW_DUE_IN,
                     default=self.entry.data.get(CONF_SHOW_DUE_IN, 7)
                 ): vol.Coerce(int),
+                vol.Optional(
+                    CONF_SHOW_ONLY_TODAY,
+                    default=self.entry.data.get(CONF_SHOW_ONLY_TODAY, False)
+                ): bool,
                 vol.Optional(
                     CONF_CREATE_UNIFIED_LIST,
                     default=self.entry.data.get(CONF_CREATE_UNIFIED_LIST, True)

--- a/custom_components/donetick/const.py
+++ b/custom_components/donetick/const.py
@@ -5,10 +5,11 @@ TODO_STORAGE_KEY = f"{DOMAIN}_items"
 CONF_URL = "url"
 CONF_TOKEN = "token"
 CONF_SHOW_DUE_IN = "show_due_in"
+CONF_SHOW_ONLY_TODAY = "show_only_today"
 CONF_CREATE_UNIFIED_LIST = "create_unified_list"
 CONF_CREATE_ASSIGNEE_LISTS = "create_assignee_lists"
 CONF_REFRESH_INTERVAL = "refresh_interval"
 
-DEFAULT_REFRESH_INTERVAL = 900 # seconds - 15 minutes
+DEFAULT_REFRESH_INTERVAL = 900  # seconds - 15 minutes
 
 API_TIMEOUT = 10  # seconds

--- a/custom_components/donetick/manifest.json
+++ b/custom_components/donetick/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "donetick",
     "name": "Donetick",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "documentation": "https://github.com/donetick/donetick-hass-integration",
     "issue_tracker": "https://github.com/donetick/donetick-hass-integration/issues",
     "dependencies": [],

--- a/custom_components/donetick/strings.json
+++ b/custom_components/donetick/strings.json
@@ -23,6 +23,10 @@
                         "name": "Days ahead to show upcoming tasks",
                         "description": "Show tasks due within this many days (0 shows all tasks)"
                     },
+                    "show_only_today": {
+                        "name": "Only show tasks due today",
+                        "description": "Hide tasks until their calendar day begins"
+                    },
                     "create_unified_list": {
                         "name": "Create \"All Tasks\" list",
                         "description": "Show all household tasks in a single todo list"
@@ -44,6 +48,10 @@
                     "show_due_in": {
                         "name": "Days ahead to show upcoming tasks",
                         "description": "Show tasks due within this many days (0 shows all tasks)"
+                    },
+                    "show_only_today": {
+                        "name": "Only show tasks due today",
+                        "description": "Hide tasks until their calendar day begins"
                     },
                     "create_unified_list": {
                         "name": "Create \"All Tasks\" list",

--- a/custom_components/donetick/strings.json
+++ b/custom_components/donetick/strings.json
@@ -24,7 +24,7 @@
                         "description": "Show tasks due within this many days (0 shows all tasks)"
                     },
                     "show_only_today": {
-                        "name": "Only show tasks due today",
+                        "name": "Show tasks due today or overdue",
                         "description": "Hide tasks until their calendar day begins"
                     },
                     "create_unified_list": {
@@ -50,7 +50,7 @@
                         "description": "Show tasks due within this many days (0 shows all tasks)"
                     },
                     "show_only_today": {
-                        "name": "Only show tasks due today",
+                        "name": "Show tasks due today or overdue",
                         "description": "Hide tasks until their calendar day begins"
                     },
                     "create_unified_list": {

--- a/custom_components/donetick/todo.py
+++ b/custom_components/donetick/todo.py
@@ -184,7 +184,8 @@ class DonetickTodoListBase(CoordinatorEntity, TodoListEntity):
             return tasks
 
         now_local = dt_util.now()
-        end_of_today = dt_util.end_of_local_day(now_local)
+        start_of_today = dt_util.start_of_local_day(now_local)
+        end_of_today = start_of_today + timedelta(days=1)
         filtered = []
         for task in tasks:
             if task.next_due_date is None:

--- a/custom_components/donetick/todo.py
+++ b/custom_components/donetick/todo.py
@@ -174,7 +174,7 @@ class DonetickTodoListBase(CoordinatorEntity, TodoListEntity):
         return self._filter_today_only(filtered)
 
     def _filter_today_only(self, tasks):
-        """Filter tasks to those due today when configured."""
+        """Filter tasks to those due today, overdue, or without due dates."""
         if not self._show_only_today:
             return tasks
 
@@ -187,7 +187,7 @@ class DonetickTodoListBase(CoordinatorEntity, TodoListEntity):
 
             normalized_due = self._normalize_due_date(task.next_due_date)
             local_due = dt_util.as_local(normalized_due)
-            if local_due.date() == today_local:
+            if local_due.date() <= today_local:
                 filtered.append(task)
 
         return filtered

--- a/custom_components/donetick/translations/en.json
+++ b/custom_components/donetick/translations/en.json
@@ -14,7 +14,7 @@
                 "description": "Choose how you'd like to organize your Donetick tasks in Home Assistant",
                 "data": {
                     "show_due_in": "Days ahead to show upcoming tasks",
-                    "show_only_today": "Only show tasks due today",
+                    "show_only_today": "Show tasks due today or overdue",
                     "create_unified_list": "Create \"All Tasks\" list",
                     "create_assignee_lists": "Create individual task lists per person"
                 }
@@ -28,7 +28,7 @@
                 "description": "Adjust your Donetick integration settings",
                 "data": {
                     "show_due_in": "Days ahead to show upcoming tasks",
-                    "show_only_today": "Only show tasks due today",
+                    "show_only_today": "Show tasks due today or overdue",
                     "create_unified_list": "Create \"All Tasks\" list",
                     "create_assignee_lists": "Create individual task lists per person"
                 }

--- a/custom_components/donetick/translations/en.json
+++ b/custom_components/donetick/translations/en.json
@@ -14,6 +14,7 @@
                 "description": "Choose how you'd like to organize your Donetick tasks in Home Assistant",
                 "data": {
                     "show_due_in": "Days ahead to show upcoming tasks",
+                    "show_only_today": "Only show tasks due today",
                     "create_unified_list": "Create \"All Tasks\" list",
                     "create_assignee_lists": "Create individual task lists per person"
                 }
@@ -27,6 +28,7 @@
                 "description": "Adjust your Donetick integration settings",
                 "data": {
                     "show_due_in": "Days ahead to show upcoming tasks",
+                    "show_only_today": "Only show tasks due today",
                     "create_unified_list": "Create \"All Tasks\" list",
                     "create_assignee_lists": "Create individual task lists per person"
                 }


### PR DESCRIPTION
I want the ability to limit the number of things synced by days. This was a config option that was not actually working, so I fixed it to work. 

I also wanted the ability to only show what needed to be done in this calendar day. This is helpful for kids who need to check everything off a list before they can go to bed or something like that. 

There was also a bug where if you checked an item off sometimes it would not clear, I fixed that bug by making sure we always trigger listeners whenever we are doing stuff with the list / api. 