### PR TITLE
fix(api): use "value" param for thing state updates

### DIFF
--- a/custom_components/donetick/api.py
+++ b/custom_components/donetick/api.py
@@ -137,7 +137,7 @@ class DonetickApiClient:
             "Content-Type": "application/json",
         }
         
-        params = {"state": state}
+        params = {"value": state}
         
         try:
             async with self._session.get(


### PR DESCRIPTION
This aims to resolve the 400 Bad request errors:

```
2025-11-04 22:06:03.496 ERROR (MainThread) [custom_components.donetick.thing] Error updating thing Zmywarka: 400, message='Bad Request', url='http://obowiazki.lan/eapi/v1/things/2/state'
2025-11-04 22:06:03.496 ERROR (MainThread) [custom_components.donetick.api] Error fetching thing state from Donetick: 400, message='Bad Request', url='http://obowiazki.lan/eapi/v1/things/1/state'
2025-11-04 22:06:03.496 ERROR (MainThread) [custom_components.donetick.thing] Error updating thing Kuweta: 400, message='Bad Request', url='http://obowiazki.lan/eapi/v1/things/1/state'
2025-11-04 22:06:33.498 ERROR (MainThread) [custom_components.donetick.api] Error fetching thing state from Donetick: 400, message='Bad Request', url='http://obowiazki.lan/eapi/v1/things/2/s
```

Resolves #25 