### PR TITLE
Add calendar entity for chores

### DIFF
--- a/custom_components/donetick/__init__.py
+++ b/custom_components/donetick/__init__.py
@@ -1,12 +1,14 @@
 """The Donetick integration."""
 import logging
+from datetime import timedelta
 import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL
 from .api import DonetickApiClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -17,10 +19,11 @@ SERVICE_COMPLETE_TASK = "complete_task"
 SERVICE_CREATE_TASK = "create_task"
 SERVICE_UPDATE_TASK = "update_task"
 SERVICE_DELETE_TASK = "delete_task"
+SERVICE_SKIP_TASK = "skip_task"
 
 COMPLETE_TASK_SCHEMA = vol.Schema({
-    vol.Required("task_id"): cv.positive_int,
-    vol.Optional("completed_by"): cv.positive_int,
+    vol.Required("task_id"): vol.Coerce(int),
+    vol.Optional("completed_by"): vol.Coerce(int),
     vol.Optional("config_entry_id"): cv.string,
 })
 
@@ -28,12 +31,12 @@ CREATE_TASK_SCHEMA = vol.Schema({
     vol.Required("name"): cv.string,
     vol.Optional("description"): cv.string,
     vol.Optional("due_date"): cv.string,
-    vol.Optional("created_by"): cv.positive_int,
+    vol.Optional("created_by"): vol.Coerce(int),
     vol.Optional("config_entry_id"): cv.string,
 })
 
 UPDATE_TASK_SCHEMA = vol.Schema({
-    vol.Required("task_id"): cv.positive_int,
+    vol.Required("task_id"): vol.Coerce(int),
     vol.Optional("name"): cv.string,
     vol.Optional("description"): cv.string,
     vol.Optional("due_date"): cv.string,
@@ -41,17 +44,51 @@ UPDATE_TASK_SCHEMA = vol.Schema({
 })
 
 DELETE_TASK_SCHEMA = vol.Schema({
-    vol.Required("task_id"): cv.positive_int,
+    vol.Required("task_id"): vol.Coerce(int),
+    vol.Optional("config_entry_id"): cv.string,
+})
+
+SKIP_TASK_SCHEMA = vol.Schema({
+    vol.Required("task_id"): vol.Coerce(int),
+    vol.Optional("completed_by"): vol.Coerce(int),
     vol.Optional("config_entry_id"): cv.string,
 })
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Donetick from a config entry."""
     hass.data.setdefault(DOMAIN, {})
+
+    session = async_get_clientsession(hass)
+    client = DonetickApiClient(
+        entry.data[CONF_URL],
+        entry.data[CONF_TOKEN],
+        session,
+    )
+
+    refresh_interval_seconds = entry.data.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL)
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="donetick_chores",
+        update_method=client.async_get_tasks,
+        update_interval=timedelta(seconds=refresh_interval_seconds),
+    )
+    await coordinator.async_config_entry_first_refresh()
+
+    # Fetch circle members for resolving user IDs to names
+    circle_members = []
+    try:
+        circle_members = await client.async_get_circle_members()
+    except Exception as e:
+        _LOGGER.warning("Failed to fetch circle members: %s", e)
+
     hass.data[DOMAIN][entry.entry_id] = {
         CONF_URL: entry.data[CONF_URL],
         CONF_TOKEN: entry.data[CONF_TOKEN],
-        CONF_SHOW_DUE_IN: entry.data.get(CONF_SHOW_DUE_IN,7),
+        CONF_SHOW_DUE_IN: entry.data.get(CONF_SHOW_DUE_IN, 7),
+        "coordinator": coordinator,
+        "client": client,
+        "circle_members": circle_members,
     }
     
     # Register services before setting up platforms
@@ -66,7 +103,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     
     async def delete_task_handler(call: ServiceCall) -> None:
         await async_delete_task_service(hass, call)
-    
+
+    async def skip_task_handler(call: ServiceCall) -> None:
+        await async_skip_task_service(hass, call)
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_COMPLETE_TASK,
@@ -91,9 +131,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         delete_task_handler,
         schema=DELETE_TASK_SCHEMA,
     )
-    _LOGGER.debug("Registered services: %s.%s, %s.%s, %s.%s, %s.%s", 
-                  DOMAIN, SERVICE_COMPLETE_TASK, DOMAIN, SERVICE_CREATE_TASK, 
-                  DOMAIN, SERVICE_UPDATE_TASK, DOMAIN, SERVICE_DELETE_TASK)
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SKIP_TASK,
+        skip_task_handler,
+        schema=SKIP_TASK_SCHEMA,
+    )
+    _LOGGER.debug("Registered services: %s.%s, %s.%s, %s.%s, %s.%s, %s.%s",
+                  DOMAIN, SERVICE_COMPLETE_TASK, DOMAIN, SERVICE_CREATE_TASK,
+                  DOMAIN, SERVICE_UPDATE_TASK, DOMAIN, SERVICE_DELETE_TASK,
+                  DOMAIN, SERVICE_SKIP_TASK)
     
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -131,27 +178,16 @@ async def async_complete_task_service(hass: HomeAssistant, call: ServiceCall) ->
             return
         entry = entries[0]
     
-    # Get API client
-    session = async_get_clientsession(hass)
-    client = DonetickApiClient(
-        hass.data[DOMAIN][entry.entry_id][CONF_URL],
-        hass.data[DOMAIN][entry.entry_id][CONF_TOKEN],
-        session,
-    )
-    
+    # Get API client and coordinator
+    config = hass.data[DOMAIN][entry.entry_id]
+    client = config["client"]
+    coordinator = config["coordinator"]
+
     try:
         result = await client.async_complete_task(task_id, completed_by)
         _LOGGER.info("Task %d completed successfully by user %s", task_id, completed_by or "default")
-        
-        # Trigger coordinator refresh for all todo entities
-        entity_registry = hass.helpers.entity_registry.async_get()
-        for entity_id in hass.states.async_entity_ids("todo"):
-            if entity_id.startswith("todo.dt_"):
-                entity_entry = entity_registry.async_get(entity_id)
-                if entity_entry and entity_entry.config_entry_id == entry.entry_id:
-                    # Trigger update - this will refresh the coordinator
-                    await hass.helpers.entity_component.async_update_entity(entity_id)
-                    
+        await coordinator.async_request_refresh()
+
     except Exception as e:
         _LOGGER.error("Failed to complete task %d: %s", task_id, e)
 
@@ -168,21 +204,16 @@ async def async_create_task_service(hass: HomeAssistant, call: ServiceCall) -> N
     if not entry:
         return
     
-    # Get API client
-    session = async_get_clientsession(hass)
-    client = DonetickApiClient(
-        hass.data[DOMAIN][entry.entry_id][CONF_URL],
-        hass.data[DOMAIN][entry.entry_id][CONF_TOKEN],
-        session,
-    )
-    
+    # Get API client and coordinator
+    config = hass.data[DOMAIN][entry.entry_id]
+    client = config["client"]
+    coordinator = config["coordinator"]
+
     try:
         result = await client.async_create_task(name, description, due_date, created_by)
         _LOGGER.info("Task '%s' created successfully with ID %d", name, result.id)
-        
-        # Trigger coordinator refresh for all todo entities
-        await _refresh_todo_entities(hass, entry.entry_id)
-                    
+        await coordinator.async_request_refresh()
+
     except Exception as e:
         _LOGGER.error("Failed to create task '%s': %s", name, e)
 
@@ -199,21 +230,16 @@ async def async_update_task_service(hass: HomeAssistant, call: ServiceCall) -> N
     if not entry:
         return
     
-    # Get API client
-    session = async_get_clientsession(hass)
-    client = DonetickApiClient(
-        hass.data[DOMAIN][entry.entry_id][CONF_URL],
-        hass.data[DOMAIN][entry.entry_id][CONF_TOKEN],
-        session,
-    )
-    
+    # Get API client and coordinator
+    config = hass.data[DOMAIN][entry.entry_id]
+    client = config["client"]
+    coordinator = config["coordinator"]
+
     try:
         result = await client.async_update_task(task_id, name, description, due_date)
         _LOGGER.info("Task %d updated successfully", task_id)
-        
-        # Trigger coordinator refresh for all todo entities
-        await _refresh_todo_entities(hass, entry.entry_id)
-                    
+        await coordinator.async_request_refresh()
+
     except Exception as e:
         _LOGGER.error("Failed to update task %d: %s", task_id, e)
 
@@ -227,26 +253,43 @@ async def async_delete_task_service(hass: HomeAssistant, call: ServiceCall) -> N
     if not entry:
         return
     
-    # Get API client
-    session = async_get_clientsession(hass)
-    client = DonetickApiClient(
-        hass.data[DOMAIN][entry.entry_id][CONF_URL],
-        hass.data[DOMAIN][entry.entry_id][CONF_TOKEN],
-        session,
-    )
-    
+    # Get API client and coordinator
+    config = hass.data[DOMAIN][entry.entry_id]
+    client = config["client"]
+    coordinator = config["coordinator"]
+
     try:
         success = await client.async_delete_task(task_id)
         if success:
             _LOGGER.info("Task %d deleted successfully", task_id)
-            
-            # Trigger coordinator refresh for all todo entities
-            await _refresh_todo_entities(hass, entry.entry_id)
+            await coordinator.async_request_refresh()
         else:
             _LOGGER.error("Failed to delete task %d", task_id)
-                    
+
     except Exception as e:
         _LOGGER.error("Failed to delete task %d: %s", task_id, e)
+
+async def async_skip_task_service(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Handle the skip_task service call."""
+    task_id = call.data["task_id"]
+    completed_by = call.data.get("completed_by")
+    config_entry_id = call.data.get("config_entry_id")
+
+    entry = await _get_config_entry(hass, config_entry_id)
+    if not entry:
+        return
+
+    config = hass.data[DOMAIN][entry.entry_id]
+    client = config["client"]
+    coordinator = config["coordinator"]
+
+    try:
+        result = await client.async_skip_task(task_id, completed_by)
+        _LOGGER.info("Task %d skipped successfully", task_id)
+        await coordinator.async_request_refresh()
+
+    except Exception as e:
+        _LOGGER.error("Failed to skip task %d: %s", task_id, e)
 
 async def _get_config_entry(hass: HomeAssistant, config_entry_id: str = None) -> ConfigEntry:
     """Get the config entry to use for the service call."""
@@ -275,16 +318,6 @@ async def _get_config_entry(hass: HomeAssistant, config_entry_id: str = None) ->
     
     return entry
 
-async def _refresh_todo_entities(hass: HomeAssistant, config_entry_id: str) -> None:
-    """Refresh all todo entities for the given config entry."""
-    entity_registry = hass.helpers.entity_registry.async_get()
-    for entity_id in hass.states.async_entity_ids("todo"):
-        if entity_id.startswith("todo.dt_"):
-            entity_entry = entity_registry.async_get(entity_id)
-            if entity_entry and entity_entry.config_entry_id == config_entry_id:
-                # Trigger update - this will refresh the coordinator
-                await hass.helpers.entity_component.async_update_entity(entity_id)
-
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
@@ -293,7 +326,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         
         # Remove services if this is the last config entry
         if not hass.data[DOMAIN]:
-            for service_name in [SERVICE_COMPLETE_TASK, SERVICE_CREATE_TASK, SERVICE_UPDATE_TASK, SERVICE_DELETE_TASK]:
+            for service_name in [SERVICE_COMPLETE_TASK, SERVICE_CREATE_TASK, SERVICE_UPDATE_TASK, SERVICE_DELETE_TASK, SERVICE_SKIP_TASK]:
                 if hass.services.has_service(DOMAIN, service_name):
                     hass.services.async_remove(DOMAIN, service_name)
             _LOGGER.debug("Removed services: %s.%s, %s.%s, %s.%s, %s.%s", 

--- a/custom_components/donetick/__init__.py
+++ b/custom_components/donetick/__init__.py
@@ -12,7 +12,7 @@ from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_REFRESH_
 from .api import DonetickApiClient
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS = [Platform.TODO, Platform.SENSOR, Platform.SWITCH, Platform.NUMBER, Platform.TEXT]
+PLATFORMS = [Platform.TODO, Platform.SENSOR, Platform.SWITCH, Platform.NUMBER, Platform.TEXT, Platform.CALENDAR]
 
 
 SERVICE_COMPLETE_TASK = "complete_task"

--- a/custom_components/donetick/api.py
+++ b/custom_components/donetick/api.py
@@ -289,6 +289,35 @@ class DonetickApiClient:
             _LOGGER.error("Error parsing Donetick update task response: %s", err)
             raise
 
+    async def async_skip_task(self, choreId: int, completed_by: int = None) -> DonetickTask:
+        """Skip a task, advancing to the next scheduled occurrence without recording a completion."""
+        headers = {
+            "secretkey": f"{self._token}",
+            "Content-Type": "application/json",
+        }
+
+        params = {}
+        if completed_by:
+            params["completedBy"] = completed_by
+
+        try:
+            async with self._session.post(
+                f"{self._base_url}/eapi/v1/chore/{choreId}/skip",
+                headers=headers,
+                params=params,
+                timeout=API_TIMEOUT
+            ) as response:
+                response.raise_for_status()
+                data = await response.json()
+                return DonetickTask.from_json(data)
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Error skipping task in Donetick: %s", err)
+            raise
+        except (KeyError, ValueError, json.JSONDecodeError) as err:
+            _LOGGER.error("Error parsing Donetick skip task response: %s", err)
+            raise
+
     async def async_delete_task(self, task_id: int) -> bool:
         """Delete a task"""
         headers = {

--- a/custom_components/donetick/calendar.py
+++ b/custom_components/donetick/calendar.py
@@ -1,0 +1,225 @@
+"""Calendar platform for Donetick."""
+import logging
+from datetime import datetime, date, timedelta
+from typing import List, Optional
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN
+from .model import DonetickTask, DonetickMember
+
+_LOGGER = logging.getLogger(__name__)
+
+# Frequency types that represent recurring chores
+RECURRING_FREQUENCY_TYPES = {
+    "daily",
+    "weekly",
+    "monthly",
+    "yearly",
+    "interval",
+    "days_of_the_week",
+    "day_of_the_month",
+    "adaptive",
+}
+
+
+def _get_member_name(members: List[DonetickMember], user_id: Optional[int]) -> Optional[str]:
+    """Resolve a user ID to a display name."""
+    if user_id is None:
+        return None
+    for member in members:
+        if member.user_id == user_id:
+            return member.display_name
+    return None
+
+
+def _task_to_event(task: DonetickTask, members: List[DonetickMember]) -> Optional[CalendarEvent]:
+    """Convert a DonetickTask to a CalendarEvent on its next_due_date."""
+    if task.next_due_date is None:
+        return None
+
+    due = task.next_due_date.date() if isinstance(task.next_due_date, datetime) else task.next_due_date
+
+    assignee = _get_member_name(members, task.assigned_to)
+    description = task.description or ""
+    if assignee:
+        description = f"Assigned to: {assignee}\n{description}".strip()
+
+    return CalendarEvent(
+        summary=task.name,
+        start=due,
+        end=due + timedelta(days=1),
+        description=description,
+        uid=f"donetick_{task.id}",
+    )
+
+
+def _generate_occurrences(
+    task: DonetickTask,
+    members: List[DonetickMember],
+    range_start: date,
+    range_end: date,
+) -> List[CalendarEvent]:
+    """Generate calendar events for a task within a date range.
+
+    For non-recurring tasks, returns the single event if it falls in range.
+    For recurring tasks, projects future occurrences based on frequency_type and frequency.
+    """
+    if task.next_due_date is None:
+        return []
+
+    anchor = task.next_due_date.date() if isinstance(task.next_due_date, datetime) else task.next_due_date
+
+    assignee = _get_member_name(members, task.assigned_to)
+    description = task.description or ""
+    if assignee:
+        description = f"Assigned to: {assignee}\n{description}".strip()
+
+    # Non-recurring: single event
+    if task.frequency_type not in RECURRING_FREQUENCY_TYPES:
+        if range_start <= anchor < range_end:
+            return [CalendarEvent(
+                summary=task.name,
+                start=anchor,
+                end=anchor + timedelta(days=1),
+                description=description,
+                uid=f"donetick_{task.id}",
+            )]
+        return []
+
+    # Recurring: compute the interval as a timedelta
+    delta = _frequency_to_delta(task.frequency_type, task.frequency)
+    if delta is None:
+        # Unsupported frequency — just show the next due date
+        if range_start <= anchor < range_end:
+            return [CalendarEvent(
+                summary=task.name,
+                start=anchor,
+                end=anchor + timedelta(days=1),
+                description=description,
+                uid=f"donetick_{task.id}",
+            )]
+        return []
+
+    events: List[CalendarEvent] = []
+    current = anchor
+
+    # Walk backwards to find occurrences before anchor but still in range
+    if current > range_start and delta.days > 0:
+        while current - delta >= range_start:
+            current = current - delta
+
+    # Walk forward through the range
+    while current < range_end:
+        if current >= range_start:
+            events.append(CalendarEvent(
+                summary=task.name,
+                start=current,
+                end=current + timedelta(days=1),
+                description=description,
+                uid=f"donetick_{task.id}_{current.isoformat()}",
+            ))
+        current = current + delta
+        # Safety: cap at 365 events
+        if len(events) >= 365:
+            break
+
+    return events
+
+
+def _frequency_to_delta(frequency_type: str, frequency: int) -> Optional[timedelta]:
+    """Convert a Donetick frequency type + multiplier to a timedelta."""
+    freq = max(frequency, 1)
+    if frequency_type == "daily" or frequency_type == "interval":
+        return timedelta(days=freq)
+    if frequency_type == "weekly" or frequency_type == "days_of_the_week":
+        return timedelta(weeks=freq)
+    if frequency_type == "monthly" or frequency_type == "day_of_the_month":
+        return timedelta(days=30 * freq)
+    if frequency_type == "yearly":
+        return timedelta(days=365 * freq)
+    # adaptive and others — can't reliably predict
+    return None
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Donetick calendar from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data["coordinator"]
+    circle_members = data.get("circle_members", [])
+
+    async_add_entities([DonetickCalendar(coordinator, circle_members, entry)])
+
+
+class DonetickCalendar(CoordinatorEntity, CalendarEntity):
+    """A calendar entity representing Donetick chores."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Chores"
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        circle_members: List[DonetickMember],
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the calendar."""
+        super().__init__(coordinator)
+        self._circle_members = circle_members
+        self._attr_unique_id = f"{entry.entry_id}_calendar"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, f"{entry.entry_id}_chores")},
+            "name": "Donetick Chores",
+            "manufacturer": "Donetick",
+        }
+
+    @property
+    def event(self) -> Optional[CalendarEvent]:
+        """Return the next upcoming event (used for the entity state)."""
+        tasks: List[DonetickTask] = self.coordinator.data or []
+        today = date.today()
+        closest_event: Optional[CalendarEvent] = None
+        closest_date: Optional[date] = None
+
+        for task in tasks:
+            if not task.is_active or task.next_due_date is None:
+                continue
+            due = task.next_due_date.date() if isinstance(task.next_due_date, datetime) else task.next_due_date
+            if closest_date is None or due < closest_date:
+                closest_date = due
+                closest_event = _task_to_event(task, self._circle_members)
+
+        return closest_event
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> List[CalendarEvent]:
+        """Return events within a date range (called by the calendar card)."""
+        tasks: List[DonetickTask] = self.coordinator.data or []
+        range_start = start_date.date() if isinstance(start_date, datetime) else start_date
+        range_end = end_date.date() if isinstance(end_date, datetime) else end_date
+
+        events: List[CalendarEvent] = []
+        for task in tasks:
+            if not task.is_active:
+                continue
+            events.extend(
+                _generate_occurrences(task, self._circle_members, range_start, range_end)
+            )
+
+        events.sort(key=lambda e: e.start)
+        return events

--- a/custom_components/donetick/chore_sensor.py
+++ b/custom_components/donetick/chore_sensor.py
@@ -1,0 +1,168 @@
+"""Donetick chore sensor entities."""
+import logging
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN
+from .model import DonetickMember, DonetickTask
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_chore_sensors(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Donetick chore sensor entities."""
+    config = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config["coordinator"]
+
+    entities = []
+    if coordinator.data:
+        for task in coordinator.data:
+            if task.is_active:
+                entities.append(DonetickChoreSensor(coordinator, config_entry, task.id))
+
+    _LOGGER.debug("Creating %d chore sensor entities", len(entities))
+    if entities:
+        async_add_entities(entities)
+
+    # Listen for coordinator updates to add/remove sensors as chores change
+    _track_new_chores(hass, coordinator, config_entry, async_add_entities)
+
+
+def _track_new_chores(
+    hass: HomeAssistant,
+    coordinator: DataUpdateCoordinator,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Track coordinator updates and add sensors for new chores."""
+    known_ids: set[int] = set()
+    if coordinator.data:
+        known_ids = {task.id for task in coordinator.data if task.is_active}
+
+    @callback
+    def _on_coordinator_update() -> None:
+        nonlocal known_ids
+        if not coordinator.data:
+            return
+
+        current_ids = {task.id for task in coordinator.data if task.is_active}
+        new_ids = current_ids - known_ids
+        removed_ids = known_ids - current_ids
+
+        if new_ids:
+            new_entities = [
+                DonetickChoreSensor(coordinator, config_entry, task_id)
+                for task_id in new_ids
+            ]
+            async_add_entities(new_entities)
+
+        if removed_ids:
+            registry = er.async_get(hass)
+            for task_id in removed_ids:
+                unique_id = f"dt_chore_{config_entry.entry_id}_{task_id}"
+                entity_id = registry.async_get_entity_id("sensor", DOMAIN, unique_id)
+                if entity_id:
+                    _LOGGER.debug("Removing sensor for inactive chore %s", task_id)
+                    registry.async_remove(entity_id)
+
+        known_ids = current_ids
+
+    coordinator.async_add_listener(_on_coordinator_update)
+
+
+class DonetickChoreSensor(CoordinatorEntity, SensorEntity):
+    """Sensor entity for a single Donetick chore."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        config_entry: ConfigEntry,
+        task_id: int,
+    ) -> None:
+        """Initialize the chore sensor."""
+        super().__init__(coordinator)
+        self._task_id = task_id
+        self._config_entry = config_entry
+        self._attr_unique_id = f"dt_chore_{config_entry.entry_id}_{task_id}"
+
+    @property
+    def _task(self) -> DonetickTask | None:
+        """Find this sensor's task in the coordinator data."""
+        if not self.coordinator.data:
+            return None
+        for task in self.coordinator.data:
+            if task.id == self._task_id:
+                return task
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Return True if the task still exists."""
+        return self._task is not None and super().available
+
+    @property
+    def name(self) -> str:
+        """Return the chore name."""
+        task = self._task
+        return task.name if task else f"Chore {self._task_id}"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the chore name as the sensor state."""
+        task = self._task
+        return task.name if task else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose chore metadata as attributes."""
+        task = self._task
+        if not task:
+            return {}
+
+        attrs = {
+            "task_id": task.id,
+            "assigned_to": self._resolve_user_name(task.assigned_to),
+            "assigned_to_user_id": task.assigned_to,
+            "next_due_date": task.next_due_date.isoformat() if task.next_due_date else None,
+            "frequency_type": task.frequency_type,
+            "frequency": task.frequency,
+            "priority": task.priority,
+            "labels": task.labels,
+            "is_active": task.is_active,
+            "description": task.description,
+        }
+        return attrs
+
+    def _resolve_user_name(self, user_id: int | None) -> str | None:
+        """Resolve a user ID to a display name using circle members."""
+        if user_id is None:
+            return None
+        config = self.hass.data[DOMAIN].get(self._config_entry.entry_id, {})
+        members: list[DonetickMember] = config.get("circle_members", [])
+        for member in members:
+            if member.user_id == user_id:
+                return member.display_name or member.username
+        return str(user_id)
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information."""
+        return {
+            "identifiers": {(DOMAIN, f"chores_{self._config_entry.entry_id}")},
+            "name": "Donetick Chores",
+            "manufacturer": "Donetick",
+            "model": "Chores",
+        }

--- a/custom_components/donetick/sensor.py
+++ b/custom_components/donetick/sensor.py
@@ -1,11 +1,15 @@
 """Donetick sensor platform."""
 from __future__ import annotations
+import logging
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .thing import async_setup_entry as thing_async_setup_entry
+from .chore_sensor import async_setup_chore_sensors
+
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -13,4 +17,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Donetick sensor entities."""
-    await thing_async_setup_entry(hass, config_entry, async_add_entities, "sensor")
+    try:
+        await thing_async_setup_entry(hass, config_entry, async_add_entities, "sensor")
+    except Exception as err:
+        _LOGGER.debug("Thing sensor setup skipped: %s", err)
+
+    await async_setup_chore_sensors(hass, config_entry, async_add_entities)

--- a/custom_components/donetick/services.yaml
+++ b/custom_components/donetick/services.yaml
@@ -101,6 +101,33 @@ update_task:
       selector:
         text:
 
+skip_task:
+  name: Skip Task
+  description: Skip a recurring task, advancing to the next scheduled occurrence without recording a completion
+  fields:
+    task_id:
+      name: Task ID
+      description: The ID of the task to skip
+      required: true
+      selector:
+        number:
+          min: 1
+          mode: box
+    completed_by:
+      name: Completed By User ID
+      description: The Donetick user ID to attribute the skip to (optional)
+      required: false
+      selector:
+        number:
+          min: 1
+          mode: box
+    config_entry_id:
+      name: Config Entry ID
+      description: The specific Donetick integration to use (optional, uses first if not specified)
+      required: false
+      selector:
+        text:
+
 delete_task:
   name: Delete Task
   description: Delete a Donetick task

--- a/custom_components/donetick/todo.py
+++ b/custom_components/donetick/todo.py
@@ -1,13 +1,13 @@
 """Todo for Donetick integration."""
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.todo import (
     TodoItem,
     TodoItemStatus,
     TodoListEntity,
-    TodoListEntityFeature, 
+    TodoListEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -18,7 +18,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_CREATE_UNIFIED_LIST, CONF_CREATE_ASSIGNEE_LISTS, CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL
+from .const import DOMAIN, CONF_URL, CONF_TOKEN, CONF_SHOW_DUE_IN, CONF_CREATE_UNIFIED_LIST, CONF_CREATE_ASSIGNEE_LISTS
 from .api import DonetickApiClient
 from .model import DonetickTask, DonetickMember
 
@@ -30,23 +30,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Donetick todo platform."""
-    session = async_get_clientsession(hass)
-    client = DonetickApiClient(
-        hass.data[DOMAIN][config_entry.entry_id][CONF_URL],
-        hass.data[DOMAIN][config_entry.entry_id][CONF_TOKEN],
-        session,
-    )
-
-    refresh_interval_seconds = config_entry.data.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL)
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name="donetick_todo",
-        update_method=client.async_get_tasks,
-        update_interval=timedelta(seconds=refresh_interval_seconds),
-    )
-
-    await coordinator.async_config_entry_first_refresh()
+    config = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config["coordinator"]
+    client = config["client"]
 
     entities = []
     

--- a/examples/card.yaml
+++ b/examples/card.yaml
@@ -1,0 +1,55 @@
+type: custom:auto-entities
+card:
+  type: entities
+  title: Chores
+  show_header_toggle: false
+filter:
+  include:
+    - attributes:
+        task_id: "*"
+      domain: sensor
+      options:
+        type: custom:mushroom-template-card
+        primary: "{{ states(entity) }}"
+        secondary: >-
+          {% set due = state_attr(entity, 'next_due_date') %}
+          {% if due %}
+            {% set due_dt = as_datetime(due) %}
+            {% set diff = (due_dt - now()).days %}
+            {% if diff < 0 %}Overdue by {{ -diff }}d
+            {% elif diff == 0 %}Due today
+            {% elif diff == 1 %}Due tomorrow
+            {% else %}Due in {{ diff }}d
+            {% endif %}
+          {% else %}No due date
+          {% endif %}
+          {% if state_attr(entity, 'assigned_to') %}
+           · Assigned: {{ state_attr(entity, 'assigned_to') }}
+          {% endif %}
+        icon: mdi:checkbox-marked-circle-outline
+        icon_color: >-
+          {% set due = state_attr(entity, 'next_due_date') %}
+          {% if due %}
+            {% set diff = (as_datetime(due) - now()).days %}
+            {% if diff < 0 %}red
+            {% elif diff == 0 %}orange
+            {% elif diff <= 2 %}amber
+            {% else %}green
+            {% endif %}
+          {% else %}grey
+          {% endif %}
+        tap_action:
+          action: perform-action
+          perform_action: script.donetick_complete_chore
+          data:
+            entity_id: "{{ entity }}"
+        hold_action:
+          action: perform-action
+          perform_action: script.donetick_postpone_chore
+          data:
+            entity_id: "{{ entity }}"
+            days: 1
+sort:
+  method: attribute
+  attribute: next_due_date
+  numeric: false

--- a/examples/chore-dashboard.yaml
+++ b/examples/chore-dashboard.yaml
@@ -1,0 +1,143 @@
+## Donetick Chore Dashboard
+##
+## This gives you a Lovelace card setup for managing chores.
+## It requires the chore sensor entities (sensor.dt_chore_*) from this integration.
+##
+## 1. Add the scripts below to your scripts.yaml (or via UI: Settings → Automations & Scenes → Scripts)
+## 2. Add the dashboard card YAML to a dashboard
+
+## ─── scripts.yaml ───────────────────────────────────────────────────────────────
+## Add these to your scripts.yaml file:
+
+# donetick_complete_chore:
+#   alias: "Complete Chore"
+#   description: "Mark a Donetick chore as done"
+#   fields:
+#     entity_id:
+#       description: "The chore sensor entity"
+#       required: true
+#       selector:
+#         entity:
+#           filter:
+#             - integration: donetick
+#               domain: sensor
+#     completed_by:
+#       description: "User ID of who completed it (optional)"
+#       required: false
+#       selector:
+#         number:
+#           min: 1
+#           mode: box
+#   sequence:
+#     - action: donetick.complete_task
+#       data:
+#         task_id: "{{ state_attr(entity_id, 'task_id') }}"
+#         completed_by: "{{ completed_by | default(state_attr(entity_id, 'assigned_to_user_id'), omit) }}"
+#
+# donetick_postpone_chore:
+#   alias: "Postpone Chore"
+#   description: "Push a chore's due date forward by N days"
+#   fields:
+#     entity_id:
+#       description: "The chore sensor entity"
+#       required: true
+#       selector:
+#         entity:
+#           filter:
+#             - integration: donetick
+#               domain: sensor
+#     days:
+#       description: "Number of days to postpone"
+#       required: true
+#       default: 1
+#       selector:
+#         number:
+#           min: 1
+#           max: 30
+#           mode: box
+#   sequence:
+#     - action: donetick.update_task
+#       data:
+#         task_id: "{{ state_attr(entity_id, 'task_id') }}"
+#         due_date: >-
+#           {{ (as_datetime(state_attr(entity_id, 'next_due_date')) + timedelta(days=days)).isoformat() }}
+
+## ─── Dashboard Card ─────────────────────────────────────────────────────────────
+## This uses auto-entities + mushroom chips to create a chore list.
+## Requirements:
+##   - HACS cards: auto-entities, mushroom, stack-in-card (all popular/common)
+##
+## If you don't have those, a simpler entities card version is at the bottom.
+
+## ─── Option A: Rich card (requires auto-entities + mushroom) ────────────────────
+##
+## type: custom:auto-entities
+## card:
+##   type: entities
+##   title: Chores
+##   show_header_toggle: false
+## filter:
+##   include:
+##     - entity_id: sensor.dt_chore_*
+##       options:
+##         type: custom:mushroom-template-card
+##         primary: "{{ states(entity) }}"
+##         secondary: >-
+##           {% set due = state_attr(entity, 'next_due_date') %}
+##           {% if due %}
+##             {% set due_dt = as_datetime(due) %}
+##             {% set diff = (due_dt - now()).days %}
+##             {% if diff < 0 %}Overdue by {{ -diff }}d
+##             {% elif diff == 0 %}Due today
+##             {% elif diff == 1 %}Due tomorrow
+##             {% else %}Due in {{ diff }}d
+##             {% endif %}
+##           {% else %}No due date
+##           {% endif %}
+##           {% if state_attr(entity, 'assigned_to') %}
+##            · Assigned: {{ state_attr(entity, 'assigned_to') }}
+##           {% endif %}
+##         icon: mdi:checkbox-marked-circle-outline
+##         icon_color: >-
+##           {% set due = state_attr(entity, 'next_due_date') %}
+##           {% if due %}
+##             {% set diff = (as_datetime(due) - now()).days %}
+##             {% if diff < 0 %}red
+##             {% elif diff == 0 %}orange
+##             {% elif diff <= 2 %}amber
+##             {% else %}green
+##             {% endif %}
+##           {% else %}grey
+##           {% endif %}
+##         tap_action:
+##           action: perform-action
+##           perform_action: script.donetick_complete_chore
+##           data:
+##             entity_id: "{{ entity }}"
+##         hold_action:
+##           action: perform-action
+##           perform_action: script.donetick_postpone_chore
+##           data:
+##             entity_id: "{{ entity }}"
+##             days: 1
+## sort:
+##   method: attribute
+##   attribute: next_due_date
+##   numeric: false
+
+## ─── Option B: Simple entities card (no extra cards needed) ─────────────────────
+##
+## type: entities
+## title: Chores
+## entities:
+##   - type: custom:template-entity-row
+##     entity: sensor.dt_chore_ENTRY_ID_1
+##     name: "{{ states('sensor.dt_chore_ENTRY_ID_1') }}"
+##     secondary: >-
+##       {% set due = state_attr('sensor.dt_chore_ENTRY_ID_1', 'next_due_date') %}
+##       {% if due %}Due: {{ as_datetime(due).strftime('%b %d') }}{% endif %}
+##     tap_action:
+##       action: call-service
+##       service: donetick.complete_task
+##       service_data:
+##         task_id: "{{ state_attr('sensor.dt_chore_ENTRY_ID_1', 'task_id') }}"

--- a/examples/scripts.yaml
+++ b/examples/scripts.yaml
@@ -1,0 +1,76 @@
+donetick_complete_chore:
+  alias: "Complete Chore"
+  fields:
+    entity_id:
+      description: "The chore sensor entity"
+      required: true
+      selector:
+        entity:
+          filter:
+            - integration: donetick
+              domain: sensor
+    completed_by:
+      description: "User ID of who completed it (optional)"
+      required: false
+      selector:
+        number:
+          min: 1
+          mode: box
+  sequence:
+    - action: donetick.complete_task
+      data:
+        task_id: "{{ state_attr(entity_id, 'task_id') | int }}"
+        completed_by: "{{ completed_by | default(state_attr(entity_id, 'assigned_to_user_id'), omit) }}"
+
+donetick_skip_chore:
+  alias: "Skip Chore"
+  description: "Skip a recurring chore, advancing to the next scheduled occurrence based on its frequency settings"
+  fields:
+    entity_id:
+      description: "The chore sensor entity"
+      required: true
+      selector:
+        entity:
+          filter:
+            - integration: donetick
+              domain: sensor
+    completed_by:
+      description: "User ID to attribute the skip to (optional)"
+      required: false
+      selector:
+        number:
+          min: 1
+          mode: box
+  sequence:
+    - action: donetick.skip_task
+      data:
+        task_id: "{{ state_attr(entity_id, 'task_id') | int }}"
+        completed_by: "{{ completed_by | default(state_attr(entity_id, 'assigned_to_user_id'), omit) }}"
+
+donetick_postpone_chore:
+  alias: "Postpone Chore"
+  description: "Shift due date by an arbitrary number of days (for ad-hoc delays; use Skip Chore to advance to the next scheduled occurrence)"
+  fields:
+    entity_id:
+      description: "The chore sensor entity"
+      required: true
+      selector:
+        entity:
+          filter:
+            - integration: donetick
+              domain: sensor
+    days:
+      description: "Number of days to postpone"
+      required: true
+      default: 1
+      selector:
+        number:
+          min: 1
+          max: 30
+          mode: box
+  sequence:
+    - action: donetick.update_task
+      data:
+        task_id: "{{ state_attr(entity_id, 'task_id') | int }}"
+        due_date: >-
+          {{ (as_datetime(state_attr(entity_id, 'next_due_date')) + timedelta(days=days)).isoformat() }}


### PR DESCRIPTION
## Summary

- Adds a `CalendarEntity` that displays chores on Home Assistant calendar dashboards
- Projects recurring chore occurrences based on frequency type and interval (daily, weekly, monthly, yearly, etc.)
- Shows assignee and description in calendar event details
- Entity state reflects the next upcoming chore

Closes #24

> **Note:** This PR depends on #34 (chore sensors + shared coordinator). It should be merged after that PR.

## Test plan

- [ ] Verify calendar entity appears after setup
- [ ] Confirm chores show on the HA calendar card on their due dates
- [ ] Verify recurring chores project future occurrences correctly
- [ ] Test that assignee names resolve in event descriptions
- [ ] Confirm calendar updates when coordinator refreshes