### PR TITLE
fix(calendar): respect interval unit and use exact month/year arithmetic

### DIFF
--- a/custom_components/donetick/calendar.py
+++ b/custom_components/donetick/calendar.py
@@ -1,7 +1,10 @@
 """Calendar platform for Donetick."""
+import json
 import logging
 from datetime import datetime, date, timedelta
-from typing import List, Optional
+from typing import List, Optional, Union
+
+from dateutil.relativedelta import relativedelta
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
@@ -95,7 +98,9 @@ def _generate_occurrences(
         return []
 
     # Recurring: compute the interval as a timedelta
-    delta = _frequency_to_delta(task.frequency_type, task.frequency)
+    delta = _frequency_to_delta(
+        task.frequency_type, task.frequency, task.frequency_metadata
+    )
     if delta is None:
         # Unsupported frequency — just show the next due date
         if range_start <= anchor < range_end:
@@ -112,7 +117,7 @@ def _generate_occurrences(
     current = anchor
 
     # Walk backwards to find occurrences before anchor but still in range
-    if current > range_start and delta.days > 0:
+    if current > range_start:
         while current - delta >= range_start:
             current = current - delta
 
@@ -134,18 +139,49 @@ def _generate_occurrences(
     return events
 
 
-def _frequency_to_delta(frequency_type: str, frequency: int) -> Optional[timedelta]:
-    """Convert a Donetick frequency type + multiplier to a timedelta."""
+def _frequency_to_delta(
+    frequency_type: str,
+    frequency: int,
+    frequency_metadata: Optional[str] = None,
+) -> Optional[Union[timedelta, relativedelta]]:
+    """Convert a Donetick frequency type + multiplier to a delta."""
     freq = max(frequency, 1)
-    if frequency_type == "daily" or frequency_type == "interval":
+    if frequency_type == "daily":
         return timedelta(days=freq)
     if frequency_type == "weekly" or frequency_type == "days_of_the_week":
         return timedelta(weeks=freq)
     if frequency_type == "monthly" or frequency_type == "day_of_the_month":
-        return timedelta(days=30 * freq)
+        return relativedelta(months=freq)
     if frequency_type == "yearly":
-        return timedelta(days=365 * freq)
+        return relativedelta(years=freq)
+    if frequency_type == "interval":
+        unit = _parse_interval_unit(frequency_metadata)
+        if unit == "hours":
+            # All-day calendar can't represent sub-day cadence; show daily.
+            return timedelta(days=1)
+        if unit == "days":
+            return timedelta(days=freq)
+        if unit == "weeks":
+            return timedelta(weeks=freq)
+        if unit == "months":
+            return relativedelta(months=freq)
+        if unit == "years":
+            return relativedelta(years=freq)
     # adaptive and others — can't reliably predict
+    return None
+
+
+def _parse_interval_unit(metadata) -> Optional[str]:
+    """Extract the 'unit' field from frequency_metadata (dict or JSON string)."""
+    if not metadata:
+        return None
+    if isinstance(metadata, dict):
+        return metadata.get("unit")
+    if isinstance(metadata, str):
+        try:
+            return json.loads(metadata).get("unit")
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            return None
     return None
 
 


### PR DESCRIPTION
## Problem

The calendar entity had two issues with how it projects recurring chores into Home Assistant's calendar:

### 1. `interval` frequency ignored its unit

When a chore is configured as a custom interval (e.g. "every 2 months"), the backend stores:

- `frequencyType = "interval"`
- `frequency = 2`
- `frequencyMetadata = { "unit": "months" }`

The calendar code grouped `interval` with `daily` and treated `frequency` as a raw day count, ignoring the unit entirely:

```python
if frequency_type == "daily" or frequency_type == "interval":
    return timedelta(days=freq)
```

Result: a chore set to "every 2 months" produced one event every **2 days**, spamming the calendar with ~15 events per month instead of one every other month.

### 2. `monthly` and `yearly` used a day-based approximation

```python
if frequency_type == "monthly":
    return timedelta(days=30 * freq)
if frequency_type == "yearly":
    return timedelta(days=365 * freq)
```

For a single projected cycle the drift is small, but for multi-cycle projections (e.g. an agenda view spanning a year) the drift accumulates and events end up in the wrong month entirely. For `monthly` (delta = 30 days) the drift stays within the same calendar month so it's not visible in monthly views, but it surfaces in agenda/year views. For `interval + months` with frequency ≥ 2 (60-day delta) it skips months outright in monthly views as well.

## Fix

- Read `frequency_metadata` to get the interval `unit` and pick the appropriate delta:
  - `hours` → `timedelta(days=1)` (the calendar entity emits all-day events, so sub-day cadence collapses to daily granularity)
  - `days` → `timedelta(days=freq)`
  - `weeks` → `timedelta(weeks=freq)`
  - `months` → `relativedelta(months=freq)`
  - `years` → `relativedelta(years=freq)`
- Use `dateutil.relativedelta` for `monthly`, `yearly`, `interval+months` and `interval+years` so projection is calendar-exact regardless of month length.
- Handle `frequencyMetadata` being either a parsed dict (current API shape after the v2 migration) or a JSON string (legacy shape) via a small `_parse_interval_unit` helper.

`dateutil` is already a transitive dependency of Home Assistant core, so no manifest change is required.

The `delta.days > 0` guard inside `_generate_occurrences` is removed because `relativedelta` doesn't expose `.days`. The guard was protecting against an infinite loop with a zero delta; all delta-producing branches now return strictly-positive values, so the guard is no longer needed.

## Reproduction

### Bug 1: `interval` ignores unit

1. Create a chore with frequency type **Interval**, **every 2 months**, next due e.g. May 1.
2. Open the Home Assistant calendar with the Donetick chores entity.
3. **Before**: the chore appears roughly every other day in the visible window (~15 events per month).
4. **After**: the chore appears once on May 1, once on Jul 1, once on Sep 1, etc., on the exact calendar date.

### Bug 2: predefined `monthly` drifts in multi-cycle views

1. Create a chore with frequency type **Monthly** (predefined), next due e.g. May 15.
2. Open the Home Assistant calendar in agenda view and scroll forward several months.
3. **Before**: dates drift backwards by ~1 day per cycle — May 15 → Jun 14 → Jul 14 → Aug 13 → ... eventually skipping a month after enough cycles.
4. **After**: every projected occurrence stays on the 15th of each month, regardless of how far ahead you scroll.

## Diff

`custom_components/donetick/calendar.py`: +44 / -8 lines.
