### PR TITLE
Fix: ToDo list does not correctly filter by the config option set in the integration options

### DIFF
--- a/custom_components/donetick/todo.py
+++ b/custom_components/donetick/todo.py
@@ -1,6 +1,6 @@
 """Todo for Donetick integration."""
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from homeassistant.components.todo import (
@@ -95,6 +95,18 @@ class DonetickTodoListBase(CoordinatorEntity, TodoListEntity):
         """Filter tasks based on entity type. Override in subclasses."""
         return tasks
 
+    def _apply_due_window(self, tasks):
+        """Apply the configured upcoming task window to filtered tasks."""
+        show_due_in = self._config_entry.data.get(CONF_SHOW_DUE_IN, 7)
+        if show_due_in is None:
+            return tasks
+
+        cutoff = datetime.now(timezone.utc) + timedelta(days=show_due_in)
+        return [
+            task for task in tasks
+            if task.next_due_date is not None and task.next_due_date <= cutoff
+        ]
+
     @property
     def todo_items(self) -> list[TodoItem] | None: 
         """Return a list of todo items."""
@@ -102,6 +114,7 @@ class DonetickTodoListBase(CoordinatorEntity, TodoListEntity):
             return None
         
         filtered_tasks = self._filter_tasks(self.coordinator.data)
+        filtered_tasks = self._apply_due_window(filtered_tasks)
         return [
             TodoItem(
                 summary=task.name,


### PR DESCRIPTION
The value is updated but never used, I imagine the implementation was overlooked 😃 

<img width="595" height="546" alt="image" src="https://github.com/user-attachments/assets/b37d6f43-de03-43ac-85b4-5ddc17dc49c1" />


**Bug description**
This PR addresses an issue with the "Days ahead to show" value that is not affecting the todo list filter.

Before: The value is not used, all tasks are shown in the todo list.
After: The value is used to filter out notes that have a due date higher than the max days set as the value. Overdue tasks remain visible.
