### PR TITLE
Improve calendar scheduling and fix timed chore rendering

### DIFF
--- a/custom_components/donetick/api.py
+++ b/custom_components/donetick/api.py
@@ -269,7 +269,7 @@ class DonetickApiClient:
             _LOGGER.error("Error parsing Donetick update task response: %s", err)
             raise
 
-    async def async_skip_task(self, choreId: int, completed_by: int = None) -> Optional[DonetickTask]:
+    async def async_skip_task(self, choreId: int, completed_by: int = None) -> DonetickTask:
         """Skip a task, advancing to the next scheduled occurrence without recording a completion."""
         headers = self._headers()
 
@@ -285,17 +285,7 @@ class DonetickApiClient:
                 timeout=API_TIMEOUT
             ) as response:
                 response.raise_for_status()
-
-                if response.status == 204:
-                    _LOGGER.debug("Donetick skip task returned no content for task %d", choreId)
-                    return None
-
-                raw_body = await response.text()
-                if not raw_body.strip():
-                    _LOGGER.debug("Donetick skip task returned an empty response for task %d", choreId)
-                    return None
-
-                data = json.loads(raw_body)
+                data = await response.json()
                 return DonetickTask.from_json(data)
 
         except aiohttp.ClientError as err:

--- a/custom_components/donetick/api.py
+++ b/custom_components/donetick/api.py
@@ -7,7 +7,7 @@ import aiohttp
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import API_TIMEOUT
-from .model import DonetickTask, DonetickThing, DonetickMember
+from .model import DonetickTask, DonetickThing, DonetickMember, DonetickChoreHistory
 _LOGGER = logging.getLogger(__name__)
 
 class DonetickApiClient:
@@ -19,12 +19,16 @@ class DonetickApiClient:
         self._token = token
         self._session = session
 
-    async def async_get_tasks(self) -> List[DonetickTask]:
-        """Get tasks from Donetick."""
-        headers = {
+    def _headers(self) -> dict:
+        """Return headers for Donetick API requests."""
+        return {
             "secretkey": f"{self._token}",
             "Content-Type": "application/json",
         }
+
+    async def async_get_tasks(self) -> List[DonetickTask]:
+        """Get tasks from Donetick."""
+        headers = self._headers()
         
         try:
             async with self._session.get(
@@ -50,10 +54,7 @@ class DonetickApiClient:
 
     async def async_get_circle_members(self) -> List[DonetickMember]:
         """Get circle members from Donetick."""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
         
         try:
             async with self._session.get(
@@ -79,10 +80,7 @@ class DonetickApiClient:
 
     async def async_get_things(self) -> List[DonetickThing]:
         """Get things from Donetick."""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
         
         try:
             async with self._session.get(
@@ -108,10 +106,7 @@ class DonetickApiClient:
 
     async def async_get_thing_state(self, thing_id: int) -> Optional[str]:
         """Get the current state of a thing."""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
         
         try:
             async with self._session.get(
@@ -132,10 +127,7 @@ class DonetickApiClient:
 
     async def async_set_thing_state(self, thing_id: int, state: str) -> bool:
         """Set the state of a thing directly."""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
         
         params = {"state": state}
         
@@ -158,10 +150,7 @@ class DonetickApiClient:
 
     async def async_change_thing_state(self, thing_id: int, new_state: str = None, increment: int = None) -> Optional[str]:
         """Change the state of a thing using the change endpoint."""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
         
         params = {}
         if new_state is not None:
@@ -189,10 +178,7 @@ class DonetickApiClient:
 
     async def async_complete_task(self, choreId: int, completed_by: int = None) -> DonetickTask:
         """Complete a task"""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
 
         # Add completed_by parameter if provided
         params = {}
@@ -222,10 +208,7 @@ class DonetickApiClient:
 
     async def async_create_task(self, name: str, description: str = None, due_date: str = None, created_by: int = None) -> DonetickTask:
         """Create a new task"""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
 
         payload = {"name": name}
         if description:
@@ -255,10 +238,7 @@ class DonetickApiClient:
 
     async def async_update_task(self, task_id: int, name: str = None, description: str = None, due_date: str = None) -> DonetickTask:
         """Update an existing task"""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
 
         payload = {}
         if name:
@@ -291,10 +271,7 @@ class DonetickApiClient:
 
     async def async_skip_task(self, choreId: int, completed_by: int = None) -> DonetickTask:
         """Skip a task, advancing to the next scheduled occurrence without recording a completion."""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
 
         params = {}
         if completed_by:
@@ -320,10 +297,7 @@ class DonetickApiClient:
 
     async def async_delete_task(self, task_id: int) -> bool:
         """Delete a task"""
-        headers = {
-            "secretkey": f"{self._token}",
-            "Content-Type": "application/json",
-        }
+        headers = self._headers()
 
         try:
             async with self._session.delete(
@@ -340,3 +314,67 @@ class DonetickApiClient:
         except Exception as err:
             _LOGGER.error("Error deleting task: %s", err)
             return False
+
+    async def async_get_task_detail(self, task_id: int) -> Optional[DonetickTask]:
+        """Get detailed task timing data when the full API endpoint is available."""
+        try:
+            async with self._session.get(
+                f"{self._base_url}/api/v1/chores/{task_id}/details",
+                headers=self._headers(),
+                timeout=API_TIMEOUT
+            ) as response:
+                if response.status in (401, 403, 404):
+                    _LOGGER.debug("Donetick task detail endpoint unavailable: HTTP %s", response.status)
+                    return None
+
+                response.raise_for_status()
+                data = await response.json()
+                detail = data.get("res", data) if isinstance(data, dict) else data
+
+                if not isinstance(detail, dict):
+                    _LOGGER.debug("Unexpected Donetick task detail response format")
+                    return None
+
+                return DonetickTask.from_json(detail)
+
+        except aiohttp.ClientError as err:
+            _LOGGER.debug("Unable to fetch Donetick task detail %d: %s", task_id, err)
+            return None
+        except (KeyError, ValueError, json.JSONDecodeError) as err:
+            _LOGGER.debug("Unable to parse Donetick task detail %d: %s", task_id, err)
+            return None
+
+    async def async_get_task_history(self, days: int = 30, include_members: bool = True) -> List[DonetickChoreHistory]:
+        """Get recent chore history when the full API endpoint is available."""
+        params = {
+            "limit": max(days, 1),
+            "members": "true" if include_members else "false",
+        }
+
+        try:
+            async with self._session.get(
+                f"{self._base_url}/api/v1/chores/history",
+                headers=self._headers(),
+                params=params,
+                timeout=API_TIMEOUT
+            ) as response:
+                if response.status in (401, 403, 404):
+                    _LOGGER.debug("Donetick task history endpoint unavailable: HTTP %s", response.status)
+                    return []
+
+                response.raise_for_status()
+                data = await response.json()
+                history = data.get("res", data) if isinstance(data, dict) else data
+
+                if not isinstance(history, list):
+                    _LOGGER.debug("Unexpected Donetick task history response format")
+                    return []
+
+                return DonetickChoreHistory.from_json_list(history)
+
+        except aiohttp.ClientError as err:
+            _LOGGER.debug("Unable to fetch Donetick task history: %s", err)
+            return []
+        except (KeyError, ValueError, json.JSONDecodeError) as err:
+            _LOGGER.debug("Unable to parse Donetick task history: %s", err)
+            return []

--- a/custom_components/donetick/api.py
+++ b/custom_components/donetick/api.py
@@ -269,7 +269,7 @@ class DonetickApiClient:
             _LOGGER.error("Error parsing Donetick update task response: %s", err)
             raise
 
-    async def async_skip_task(self, choreId: int, completed_by: int = None) -> DonetickTask:
+    async def async_skip_task(self, choreId: int, completed_by: int = None) -> Optional[DonetickTask]:
         """Skip a task, advancing to the next scheduled occurrence without recording a completion."""
         headers = self._headers()
 
@@ -285,7 +285,17 @@ class DonetickApiClient:
                 timeout=API_TIMEOUT
             ) as response:
                 response.raise_for_status()
-                data = await response.json()
+
+                if response.status == 204:
+                    _LOGGER.debug("Donetick skip task returned no content for task %d", choreId)
+                    return None
+
+                raw_body = await response.text()
+                if not raw_body.strip():
+                    _LOGGER.debug("Donetick skip task returned an empty response for task %d", choreId)
+                    return None
+
+                data = json.loads(raw_body)
                 return DonetickTask.from_json(data)
 
         except aiohttp.ClientError as err:

--- a/custom_components/donetick/calendar.py
+++ b/custom_components/donetick/calendar.py
@@ -35,27 +35,6 @@ HISTORY_STATUS_LABELS = {
     6: "Rescheduled",
 }
 
-# Frequency types that represent recurring chores
-RECURRING_FREQUENCY_TYPES = {
-    "daily",
-    "weekly",
-    "monthly",
-    "yearly",
-    "interval",
-    "days_of_the_week",
-    "day_of_the_month",
-    "adaptive",
-}
-
-# Only these recurrence types are safe to project without fully parsing frequencyMetadata.
-PROJECTABLE_FREQUENCY_TYPES = {
-    "daily",
-    "weekly",
-    "interval",
-    "yearly",
-}
-
-
 def _get_member_name(members: List[DonetickMember], user_id: Optional[int]) -> Optional[str]:
     """Resolve a user ID to a display name."""
     if user_id is None:
@@ -75,6 +54,16 @@ def _task_description(task: DonetickTask, members: List[DonetickMember]) -> str:
     return description
 
 
+def _is_date_only_due(value: datetime) -> bool:
+    """Return true when a due datetime is acting like an all-day date marker."""
+    return (value.hour, value.minute, value.second, value.microsecond) in {
+        (0, 0, 0, 0),
+        (23, 59, 0, 0),
+        (23, 59, 59, 0),
+        (23, 59, 59, 999999),
+    }
+
+
 def _best_task_start(task: DonetickTask) -> Optional[datetime | date]:
     """Return the best start time for an active/scheduled task."""
     if task.status in (CHORE_STATUS_IN_PROGRESS, CHORE_STATUS_PAUSED):
@@ -83,7 +72,10 @@ def _best_task_start(task: DonetickTask) -> Optional[datetime | date]:
     if task.next_due_date is None:
         return None
 
-    return task.next_due_date.date()
+    if _is_date_only_due(task.next_due_date):
+        return task.next_due_date.date()
+
+    return task.next_due_date
 
 
 def _event_end(start: datetime | date, duration: timedelta) -> datetime | date:
@@ -133,115 +125,6 @@ def _task_to_event(task: DonetickTask, members: List[DonetickMember]) -> Optiona
         description=_task_description(task, members),
         uid=f"donetick_{task.id}",
     )
-
-
-def _generate_occurrences(
-    task: DonetickTask,
-    members: List[DonetickMember],
-    range_start: datetime,
-    range_end: datetime,
-) -> List[CalendarEvent]:
-    """Generate calendar events for a task within a date range.
-
-    For non-recurring tasks, returns the single event if it falls in range.
-    For recurring tasks, projects future occurrences based on frequency_type and frequency.
-    """
-    anchor = _best_task_start(task)
-    if anchor is None:
-        return []
-
-    description = _task_description(task, members)
-    event_duration = (
-        DEFAULT_LOGGED_DURATION
-        if task.status in (CHORE_STATUS_IN_PROGRESS, CHORE_STATUS_PAUSED)
-        else DEFAULT_SCHEDULED_DURATION
-    )
-
-    # Non-recurring: single event
-    if task.frequency_type not in RECURRING_FREQUENCY_TYPES:
-        event = CalendarEvent(
-            summary=task.name,
-            start=anchor,
-            end=_event_end(anchor, event_duration),
-            description=description,
-            uid=f"donetick_{task.id}",
-        )
-        if _event_in_range(event, range_start, range_end):
-            return [event]
-        return []
-
-    # Recurring: only project patterns we can model correctly from the current task shape.
-    if task.frequency_type not in PROJECTABLE_FREQUENCY_TYPES:
-        event = CalendarEvent(
-            summary=task.name,
-            start=anchor,
-            end=_event_end(anchor, event_duration),
-            description=description,
-            uid=f"donetick_{task.id}",
-        )
-        if _event_in_range(event, range_start, range_end):
-            return [event]
-        return []
-
-    # Recurring: compute the interval as a timedelta
-    delta = _frequency_to_delta(task.frequency_type, task.frequency)
-    if delta is None:
-        # Unsupported frequency, just show the next due date.
-        event = CalendarEvent(
-            summary=task.name,
-            start=anchor,
-            end=_event_end(anchor, event_duration),
-            description=description,
-            uid=f"donetick_{task.id}",
-        )
-        if _event_in_range(event, range_start, range_end):
-            return [event]
-        return []
-
-    events: List[CalendarEvent] = []
-    current = anchor
-    current_key = _comparison_datetime(current)
-    range_start_key = _comparison_datetime(range_start)
-    range_end_key = _comparison_datetime(range_end)
-
-    # Walk backwards to find occurrences before anchor but still in range.
-    if current_key > range_start_key and delta.total_seconds() > 0:
-        while current_key - delta >= range_start_key:
-            current = current - delta
-            current_key = current_key - delta
-
-    # Walk forward through the range.
-    while current_key < range_end_key:
-        event = CalendarEvent(
-            summary=task.name,
-            start=current,
-            end=_event_end(current, event_duration),
-            description=description,
-            uid=f"donetick_{task.id}_{current.isoformat()}",
-        )
-        if _event_in_range(event, range_start, range_end):
-            events.append(event)
-        current = current + delta
-        current_key = current_key + delta
-        if len(events) >= 365:
-            break
-
-    return events
-
-
-def _frequency_to_delta(frequency_type: str, frequency: int) -> Optional[timedelta]:
-    """Convert a Donetick frequency type + multiplier to a timedelta."""
-    freq = max(frequency, 1)
-    if frequency_type == "daily" or frequency_type == "interval":
-        return timedelta(days=freq)
-    if frequency_type == "weekly" or frequency_type == "days_of_the_week":
-        return timedelta(weeks=freq)
-    if frequency_type == "monthly" or frequency_type == "day_of_the_month":
-        return timedelta(days=30 * freq)
-    if frequency_type == "yearly":
-        return timedelta(days=365 * freq)
-    # Adaptive and others cannot be reliably predicted.
-    return None
 
 
 def _history_to_event(
@@ -296,15 +179,6 @@ def _history_to_event(
     )
 
 
-def _event_day(event: CalendarEvent) -> date:
-    """Return the local calendar day for an event start."""
-    if isinstance(event.start, datetime):
-        if event.start.tzinfo is not None:
-            return event.start.astimezone().date()
-        return event.start.date()
-    return event.start
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -316,7 +190,12 @@ async def async_setup_entry(
     client = data["client"]
     circle_members = data.get("circle_members", [])
 
-    async_add_entities([DonetickCalendar(coordinator, client, circle_members, entry)])
+    async_add_entities(
+        [
+            DonetickCalendar(coordinator, client, circle_members, entry),
+            DonetickActivityCalendar(coordinator, client, circle_members, entry),
+        ]
+    )
 
 
 class DonetickCalendar(CoordinatorEntity, CalendarEntity):
@@ -384,9 +263,7 @@ class DonetickCalendar(CoordinatorEntity, CalendarEntity):
             if isinstance(end_date, datetime)
             else datetime.combine(end_date, datetime.min.time())
         )
-        tasks_by_id = {task.id: task for task in tasks}
-
-        scheduled_events: List[CalendarEvent] = []
+        events: List[CalendarEvent] = []
         for task in tasks:
             if not task.is_active:
                 continue
@@ -396,44 +273,81 @@ class DonetickCalendar(CoordinatorEntity, CalendarEntity):
                     task.start_time = detail.start_time
                     task.timer_updated_at = detail.timer_updated_at
                     task.duration = detail.duration
-            scheduled_events.extend(
-                _generate_occurrences(task, self._circle_members, range_start, range_end)
-            )
+            event = _task_to_event(task, self._circle_members)
+            if event is not None and _event_in_range(event, range_start, range_end):
+                events.append(event)
 
-        events: List[CalendarEvent] = []
-        history_days_by_chore: dict[int, set[date]] = {}
+        events.sort(key=_event_sort_key)
+        return events
+
+
+class DonetickActivityCalendar(CoordinatorEntity, CalendarEntity):
+    """A calendar entity representing Donetick chore activity history."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Activity Log"
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        client: DonetickApiClient,
+        circle_members: List[DonetickMember],
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the activity log calendar."""
+        super().__init__(coordinator)
+        self._client = client
+        self._circle_members = circle_members
+        self._attr_unique_id = f"{entry.entry_id}_activity_calendar"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, f"{entry.entry_id}_chores")},
+            "name": "Donetick Chores",
+            "manufacturer": "Donetick",
+        }
+
+    @property
+    def event(self) -> Optional[CalendarEvent]:
+        """Return the next upcoming event."""
+        return None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> List[CalendarEvent]:
+        """Return activity log events within a date range."""
+        tasks: List[DonetickTask] = self.coordinator.data or []
+        range_start = (
+            start_date
+            if isinstance(start_date, datetime)
+            else datetime.combine(start_date, datetime.min.time())
+        )
+        range_end = (
+            end_date
+            if isinstance(end_date, datetime)
+            else datetime.combine(end_date, datetime.min.time())
+        )
+        tasks_by_id = {task.id: task for task in tasks}
+
         now = datetime.now(timezone.utc)
         range_start_key = _comparison_datetime(range_start)
         range_end_key = _comparison_datetime(range_end)
         now_key = _comparison_datetime(now)
-        if range_start_key <= now_key and (range_end_key - range_start_key).days <= HISTORY_LOOKBACK_DAYS:
-            history_days = max((now_key - range_start_key).days + 1, 1)
-            histories = await self._client.async_get_task_history(
-                min(history_days, HISTORY_LOOKBACK_DAYS),
-                include_members=True,
-            )
-            for history in histories:
-                event = _history_to_event(history, tasks_by_id, self._circle_members)
-                if event is not None and _event_in_range(event, range_start, range_end):
-                    history_days_by_chore.setdefault(history.chore_id, set()).add(_event_day(event))
-                    events.append(event)
+        if range_start_key > now_key or (range_end_key - range_start_key).days > HISTORY_LOOKBACK_DAYS:
+            return []
 
-        for event in scheduled_events:
-            uid = event.uid or ""
-            if not uid.startswith("donetick_") or uid.startswith("donetick_history_"):
+        history_days = max((now_key - range_start_key).days + 1, 1)
+        histories = await self._client.async_get_task_history(
+            min(history_days, HISTORY_LOOKBACK_DAYS),
+            include_members=True,
+        )
+
+        events: List[CalendarEvent] = []
+        for history in histories:
+            event = _history_to_event(history, tasks_by_id, self._circle_members)
+            if event is not None and _event_in_range(event, range_start, range_end):
                 events.append(event)
-                continue
-
-            chore_id = uid.removeprefix("donetick_").split("_", 1)[0]
-            try:
-                chore_id_int = int(chore_id)
-            except ValueError:
-                events.append(event)
-                continue
-
-            if _event_day(event) in history_days_by_chore.get(chore_id_int, set()):
-                continue
-            events.append(event)
 
         events.sort(key=_event_sort_key)
         return events

--- a/custom_components/donetick/calendar.py
+++ b/custom_components/donetick/calendar.py
@@ -72,7 +72,10 @@ def _best_task_start(task: DonetickTask) -> Optional[datetime | date]:
     if task.status in (CHORE_STATUS_IN_PROGRESS, CHORE_STATUS_PAUSED):
         return task.start_time or task.timer_updated_at or task.updated_at or task.next_due_date
 
-    return task.next_due_date
+    if task.next_due_date is None:
+        return None
+
+    return task.next_due_date.date()
 
 
 def _event_end(start: datetime | date, duration: timedelta) -> datetime | date:
@@ -272,6 +275,15 @@ def _history_to_event(
     )
 
 
+def _event_day(event: CalendarEvent) -> date:
+    """Return the local calendar day for an event start."""
+    if isinstance(event.start, datetime):
+        if event.start.tzinfo is not None:
+            return event.start.astimezone().date()
+        return event.start.date()
+    return event.start
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -353,7 +365,7 @@ class DonetickCalendar(CoordinatorEntity, CalendarEntity):
         )
         tasks_by_id = {task.id: task for task in tasks}
 
-        events: List[CalendarEvent] = []
+        scheduled_events: List[CalendarEvent] = []
         for task in tasks:
             if not task.is_active:
                 continue
@@ -363,10 +375,12 @@ class DonetickCalendar(CoordinatorEntity, CalendarEntity):
                     task.start_time = detail.start_time
                     task.timer_updated_at = detail.timer_updated_at
                     task.duration = detail.duration
-            events.extend(
+            scheduled_events.extend(
                 _generate_occurrences(task, self._circle_members, range_start, range_end)
             )
 
+        events: List[CalendarEvent] = []
+        history_days_by_chore: dict[int, set[date]] = {}
         now = datetime.now(timezone.utc)
         range_start_key = _comparison_datetime(range_start)
         range_end_key = _comparison_datetime(range_end)
@@ -380,7 +394,25 @@ class DonetickCalendar(CoordinatorEntity, CalendarEntity):
             for history in histories:
                 event = _history_to_event(history, tasks_by_id, self._circle_members)
                 if event is not None and _event_in_range(event, range_start, range_end):
+                    history_days_by_chore.setdefault(history.chore_id, set()).add(_event_day(event))
                     events.append(event)
+
+        for event in scheduled_events:
+            uid = event.uid or ""
+            if not uid.startswith("donetick_") or uid.startswith("donetick_history_"):
+                events.append(event)
+                continue
+
+            chore_id = uid.removeprefix("donetick_").split("_", 1)[0]
+            try:
+                chore_id_int = int(chore_id)
+            except ValueError:
+                events.append(event)
+                continue
+
+            if _event_day(event) in history_days_by_chore.get(chore_id_int, set()):
+                continue
+            events.append(event)
 
         events.sort(key=_event_sort_key)
         return events

--- a/custom_components/donetick/calendar.py
+++ b/custom_components/donetick/calendar.py
@@ -47,6 +47,14 @@ RECURRING_FREQUENCY_TYPES = {
     "adaptive",
 }
 
+# Only these recurrence types are safe to project without fully parsing frequencyMetadata.
+PROJECTABLE_FREQUENCY_TYPES = {
+    "daily",
+    "weekly",
+    "interval",
+    "yearly",
+}
+
 
 def _get_member_name(members: List[DonetickMember], user_id: Optional[int]) -> Optional[str]:
     """Resolve a user ID to a display name."""
@@ -151,6 +159,19 @@ def _generate_occurrences(
 
     # Non-recurring: single event
     if task.frequency_type not in RECURRING_FREQUENCY_TYPES:
+        event = CalendarEvent(
+            summary=task.name,
+            start=anchor,
+            end=_event_end(anchor, event_duration),
+            description=description,
+            uid=f"donetick_{task.id}",
+        )
+        if _event_in_range(event, range_start, range_end):
+            return [event]
+        return []
+
+    # Recurring: only project patterns we can model correctly from the current task shape.
+    if task.frequency_type not in PROJECTABLE_FREQUENCY_TYPES:
         event = CalendarEvent(
             summary=task.name,
             start=anchor,

--- a/custom_components/donetick/calendar.py
+++ b/custom_components/donetick/calendar.py
@@ -2,6 +2,7 @@
 import logging
 from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
@@ -21,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_SCHEDULED_DURATION = timedelta(hours=1)
 DEFAULT_LOGGED_DURATION = timedelta(minutes=1)
 HISTORY_LOOKBACK_DAYS = 90
+MAX_PROJECTED_OCCURRENCES = 365
 
 CHORE_STATUS_IN_PROGRESS = 1
 CHORE_STATUS_PAUSED = 2
@@ -33,6 +35,17 @@ HISTORY_STATUS_LABELS = {
     4: "Rejected",
     5: "Missed",
     6: "Rescheduled",
+}
+
+RECURRING_FREQUENCY_TYPES = {
+    "daily",
+    "weekly",
+    "monthly",
+    "yearly",
+    "interval",
+    "days_of_the_week",
+    "day_of_the_month",
+    "adaptive",
 }
 
 def _get_member_name(members: List[DonetickMember], user_id: Optional[int]) -> Optional[str]:
@@ -52,6 +65,90 @@ def _task_description(task: DonetickTask, members: List[DonetickMember]) -> str:
     if assignee:
         description = f"Assigned to: {assignee}\n{description}".strip()
     return description
+
+
+def _metadata_dict(task: DonetickTask) -> dict:
+    """Return frequency metadata as a dict."""
+    return task.frequency_metadata if isinstance(task.frequency_metadata, dict) else {}
+
+
+def _metadata_time(task: DonetickTask) -> Optional[datetime]:
+    """Return the metadata time value if present."""
+    time_value = _metadata_dict(task).get("time")
+    if not isinstance(time_value, str) or not time_value:
+        return None
+    try:
+        return datetime.fromisoformat(time_value.replace("Z", "+00:00"))
+    except ValueError:
+        _LOGGER.debug("Unable to parse Donetick frequencyMetadata.time: %s", time_value)
+        return None
+
+
+def _metadata_timezone(task: DonetickTask) -> timezone | ZoneInfo:
+    """Return the task timezone from metadata, falling back to UTC."""
+    timezone_name = _metadata_dict(task).get("timezone")
+    if isinstance(timezone_name, str) and timezone_name:
+        try:
+            return ZoneInfo(timezone_name)
+        except ZoneInfoNotFoundError:
+            _LOGGER.debug("Unknown Donetick timezone %s, falling back to UTC", timezone_name)
+    return timezone.utc
+
+
+def _metadata_days(task: DonetickTask) -> list[str]:
+    """Return lower-cased weekday names from metadata."""
+    days = _metadata_dict(task).get("days")
+    if not isinstance(days, list):
+        return []
+    normalized_days: list[str] = []
+    for day in days:
+        if isinstance(day, str) and day:
+            normalized_days.append(day.lower())
+    return normalized_days
+
+
+def _metadata_months(task: DonetickTask) -> list[str]:
+    """Return lower-cased month names from metadata."""
+    months = _metadata_dict(task).get("months")
+    if not isinstance(months, list):
+        return []
+    normalized_months: list[str] = []
+    for month in months:
+        if isinstance(month, str) and month:
+            normalized_months.append(month.lower())
+    return normalized_months
+
+
+def _metadata_unit(task: DonetickTask) -> Optional[str]:
+    """Return the interval unit from metadata."""
+    unit = _metadata_dict(task).get("unit")
+    return unit if isinstance(unit, str) and unit else None
+
+
+def _metadata_week_pattern(task: DonetickTask) -> str:
+    """Return the recurrence week pattern."""
+    pattern = _metadata_dict(task).get("weekPattern")
+    if not isinstance(pattern, str) or not pattern:
+        return "every_week"
+    return pattern
+
+
+def _metadata_occurrences(task: DonetickTask) -> list[str]:
+    """Return normalized occurrence values from metadata."""
+    metadata = _metadata_dict(task)
+    occurrences = metadata.get("occurrences")
+    if isinstance(occurrences, list) and occurrences:
+        normalized: list[str] = []
+        for occurrence in occurrences:
+            if isinstance(occurrence, int):
+                normalized.append("last" if occurrence == -1 else str(occurrence))
+        return normalized
+
+    week_numbers = metadata.get("weekNumbers")
+    if isinstance(week_numbers, list):
+        return [str(value) for value in week_numbers if isinstance(value, int)]
+
+    return []
 
 
 def _is_date_only_due(value: datetime) -> bool:
@@ -125,6 +222,264 @@ def _task_to_event(task: DonetickTask, members: List[DonetickMember]) -> Optiona
         description=_task_description(task, members),
         uid=f"donetick_{task.id}",
     )
+
+
+def _normalize_occurrence_start(task: DonetickTask, due_value: datetime) -> datetime | date:
+    """Normalize a due datetime to the display start used by the calendar."""
+    if _is_date_only_due(due_value):
+        return due_value.date()
+    return due_value
+
+
+def _scheduled_task_event(
+    task: DonetickTask,
+    members: List[DonetickMember],
+    due_value: datetime,
+    uid_suffix: str = "",
+) -> CalendarEvent:
+    """Build a scheduled task calendar event from a due datetime."""
+    start = _normalize_occurrence_start(task, due_value)
+    uid = f"donetick_{task.id}" if not uid_suffix else f"donetick_{task.id}_{uid_suffix}"
+    return CalendarEvent(
+        summary=task.name,
+        start=start,
+        end=_event_end(start, DEFAULT_SCHEDULED_DURATION),
+        description=_task_description(task, members),
+        uid=uid,
+    )
+
+
+def _month_last_day(year: int, month: int) -> int:
+    """Return the last valid day number for a month."""
+    if month == 12:
+        next_month = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+    else:
+        next_month = datetime(year, month + 1, 1, tzinfo=timezone.utc)
+    return (next_month - timedelta(days=1)).day
+
+
+def _add_months(value: datetime, months: int) -> datetime:
+    """Add months to a datetime, clamping the day when needed."""
+    month_index = value.month - 1 + months
+    year = value.year + month_index // 12
+    month = month_index % 12 + 1
+    day = min(value.day, _month_last_day(year, month))
+    return value.replace(year=year, month=month, day=day)
+
+
+def _add_years(value: datetime, years: int) -> datetime:
+    """Add years to a datetime, clamping leap-day when needed."""
+    try:
+        return value.replace(year=value.year + years)
+    except ValueError:
+        return value.replace(year=value.year + years, day=28)
+
+
+def _apply_due_time(task: DonetickTask, base_date: datetime) -> datetime:
+    """Apply the metadata time-of-day to a base datetime."""
+    metadata_time = _metadata_time(task)
+    if metadata_time is None:
+        return base_date
+
+    metadata_time = metadata_time.astimezone(timezone.utc)
+    return datetime(
+        base_date.year,
+        base_date.month,
+        base_date.day,
+        metadata_time.hour,
+        metadata_time.minute,
+        metadata_time.second,
+        0,
+        tzinfo=timezone.utc,
+    )
+
+
+def _get_nth_occurrence_in_month(value: datetime) -> int:
+    """Return the 1-based weekday occurrence within the month."""
+    weekday = value.weekday()
+    occurrence = 0
+    current = value.replace(day=1)
+    while current.date() <= value.date():
+        if current.weekday() == weekday:
+            occurrence += 1
+        current += timedelta(days=1)
+    return occurrence
+
+
+def _is_last_occurrence_in_month(value: datetime) -> bool:
+    """Return true if this is the last weekday occurrence in the month."""
+    return (value + timedelta(days=7)).month != value.month
+
+
+def _get_nth_occurrence_in_quarter(value: datetime) -> int:
+    """Return the 1-based weekday occurrence within the quarter."""
+    quarter_start_month = ((value.month - 1) // 3) * 3 + 1
+    current = value.replace(month=quarter_start_month, day=1)
+    weekday = value.weekday()
+    occurrence = 0
+    while current.date() <= value.date():
+        if current.weekday() == weekday:
+            occurrence += 1
+        current += timedelta(days=1)
+    return occurrence
+
+
+def _is_last_occurrence_in_quarter(value: datetime) -> bool:
+    """Return true if this is the last weekday occurrence in the quarter."""
+    current_quarter = (value.month - 1) // 3
+    next_week = value + timedelta(days=7)
+    return next_week.year != value.year or ((next_week.month - 1) // 3) != current_quarter
+
+
+def _find_next_due_for_occurrence_pattern(
+    base_date: datetime,
+    days: list[str],
+    occurrences: list[str],
+    is_monthly: bool,
+) -> Optional[datetime]:
+    """Find the next due date for week-of-month or week-of-quarter schedules."""
+    day_set = set(days)
+    occurrence_set = set(occurrences)
+    current = base_date + timedelta(days=1)
+
+    for _ in range(730):
+        weekday_name = current.strftime("%A").lower()
+        if weekday_name in day_set:
+            if is_monthly:
+                nth = str(_get_nth_occurrence_in_month(current))
+                if nth in occurrence_set or ("last" in occurrence_set and _is_last_occurrence_in_month(current)):
+                    return current
+            else:
+                nth = str(_get_nth_occurrence_in_quarter(current))
+                if nth in occurrence_set or ("last" in occurrence_set and _is_last_occurrence_in_quarter(current)):
+                    return current
+        current += timedelta(days=1)
+
+    return None
+
+
+def _schedule_next_due(task: DonetickTask, current_due: datetime) -> Optional[datetime]:
+    """Mirror Donetick's recurrence scheduling for projecting future events."""
+    frequency_type = task.frequency_type
+    if frequency_type in {"once", "no_repeat", "trigger"}:
+        return None
+
+    base_date = current_due.astimezone(timezone.utc)
+
+    if frequency_type in {"day_of_the_month", "days_of_the_week", "interval"}:
+        base_date = _apply_due_time(task, base_date)
+
+    if frequency_type == "daily":
+        return base_date + timedelta(days=1)
+    if frequency_type == "weekly":
+        return base_date + timedelta(days=7)
+    if frequency_type == "monthly":
+        return _add_months(base_date, 1)
+    if frequency_type == "yearly":
+        return _add_years(base_date, 1)
+    if frequency_type == "adaptive":
+        return None
+    if frequency_type == "interval":
+        unit = _metadata_unit(task)
+        freq = max(task.frequency, 1)
+        if unit == "hours":
+            return base_date + timedelta(hours=freq)
+        if unit == "days":
+            return base_date + timedelta(days=freq)
+        if unit == "weeks":
+            return base_date + timedelta(weeks=freq)
+        if unit == "months":
+            return _add_months(base_date, freq)
+        if unit == "years":
+            return _add_years(base_date, freq)
+        return None
+    if frequency_type == "days_of_the_week":
+        days = _metadata_days(task)
+        if not days:
+            return None
+
+        week_pattern = _metadata_week_pattern(task)
+        if week_pattern in {"", "every_week"}:
+            tzinfo = _metadata_timezone(task)
+            localized_base = base_date.astimezone(tzinfo)
+            for offset in range(1, 8):
+                candidate = localized_base + timedelta(days=offset)
+                if candidate.strftime("%A").lower() in days:
+                    return candidate.astimezone(timezone.utc)
+            return None
+
+        occurrences = _metadata_occurrences(task)
+        if not occurrences:
+            return None
+
+        if week_pattern == "week_of_month":
+            return _find_next_due_for_occurrence_pattern(base_date, days, occurrences, True)
+        if week_pattern == "week_of_quarter":
+            return _find_next_due_for_occurrence_pattern(base_date, days, occurrences, False)
+        return None
+    if frequency_type == "day_of_the_month":
+        months = _metadata_months(task)
+        target_day = task.frequency
+        if not months or target_day <= 0 or target_day > 31:
+            return None
+
+        search_base = current_due.astimezone(timezone.utc)
+        if task.is_rolling:
+            search_base = search_base + timedelta(seconds=1)
+
+        base_with_time = _apply_due_time(task, search_base)
+        for offset in range(1, 13):
+            candidate = _add_months(base_with_time, offset)
+            if candidate.strftime("%B").lower() not in months:
+                continue
+
+            due_day = min(target_day, _month_last_day(candidate.year, candidate.month))
+            return candidate.replace(day=due_day, second=0, microsecond=0)
+
+        return None
+
+    return None
+
+
+def _generate_occurrences(
+    task: DonetickTask,
+    members: List[DonetickMember],
+    range_start: datetime,
+    range_end: datetime,
+) -> List[CalendarEvent]:
+    """Generate scheduled events for a task within a date range."""
+    if task.status in (CHORE_STATUS_IN_PROGRESS, CHORE_STATUS_PAUSED):
+        event = _task_to_event(task, members)
+        if event is None:
+            return []
+        return [event] if _event_in_range(event, range_start, range_end) else []
+
+    if task.next_due_date is None:
+        return []
+
+    events: List[CalendarEvent] = []
+    current_due = task.next_due_date
+    current_event = _scheduled_task_event(task, members, current_due)
+    if _event_in_range(current_event, range_start, range_end):
+        events.append(current_event)
+
+    if task.frequency_type not in RECURRING_FREQUENCY_TYPES:
+        return events
+
+    range_end_key = _comparison_datetime(range_end)
+    next_due = current_due
+    for _ in range(MAX_PROJECTED_OCCURRENCES):
+        next_due = _schedule_next_due(task, next_due)
+        if next_due is None:
+            break
+
+        next_event = _scheduled_task_event(task, members, next_due, next_due.isoformat())
+        if _comparison_datetime(next_event.start) > range_end_key:
+            break
+        if _event_in_range(next_event, range_start, range_end):
+            events.append(next_event)
+
+    return events
 
 
 def _history_to_event(
@@ -273,9 +628,7 @@ class DonetickCalendar(CoordinatorEntity, CalendarEntity):
                     task.start_time = detail.start_time
                     task.timer_updated_at = detail.timer_updated_at
                     task.duration = detail.duration
-            event = _task_to_event(task, self._circle_members)
-            if event is not None and _event_in_range(event, range_start, range_end):
-                events.append(event)
+            events.extend(_generate_occurrences(task, self._circle_members, range_start, range_end))
 
         events.sort(key=_event_sort_key)
         return events

--- a/custom_components/donetick/calendar.py
+++ b/custom_components/donetick/calendar.py
@@ -163,9 +163,9 @@ def _is_date_only_due(value: datetime) -> bool:
 
 
 def _task_has_due_time(task: DonetickTask) -> bool:
-    """Return true only when Donetick reports an explicit scheduled time."""
-    if _metadata_dict(task) or task.frequency_type in RECURRING_FREQUENCY_TYPES:
-        return _metadata_time(task) is not None
+    """Return true when the task has a meaningful due time."""
+    if _metadata_time(task) is not None:
+        return True
 
     return task.next_due_date is not None and not _is_date_only_due(task.next_due_date)
 

--- a/custom_components/donetick/calendar.py
+++ b/custom_components/donetick/calendar.py
@@ -1,6 +1,6 @@
 """Calendar platform for Donetick."""
 import logging
-from datetime import datetime, date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
@@ -12,10 +12,28 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
+from .api import DonetickApiClient
 from .const import DOMAIN
-from .model import DonetickTask, DonetickMember
+from .model import DonetickChoreHistory, DonetickMember, DonetickTask
 
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_SCHEDULED_DURATION = timedelta(hours=1)
+DEFAULT_LOGGED_DURATION = timedelta(minutes=1)
+HISTORY_LOOKBACK_DAYS = 90
+
+CHORE_STATUS_IN_PROGRESS = 1
+CHORE_STATUS_PAUSED = 2
+
+HISTORY_STATUS_LABELS = {
+    0: "Started",
+    1: "Completed",
+    2: "Skipped",
+    3: "Pending approval",
+    4: "Rejected",
+    5: "Missed",
+    6: "Rescheduled",
+}
 
 # Frequency types that represent recurring chores
 RECURRING_FREQUENCY_TYPES = {
@@ -40,23 +58,68 @@ def _get_member_name(members: List[DonetickMember], user_id: Optional[int]) -> O
     return None
 
 
-def _task_to_event(task: DonetickTask, members: List[DonetickMember]) -> Optional[CalendarEvent]:
-    """Convert a DonetickTask to a CalendarEvent on its next_due_date."""
-    if task.next_due_date is None:
-        return None
-
-    due = task.next_due_date.date() if isinstance(task.next_due_date, datetime) else task.next_due_date
-
+def _task_description(task: DonetickTask, members: List[DonetickMember]) -> str:
+    """Build a calendar description for a task."""
     assignee = _get_member_name(members, task.assigned_to)
     description = task.description or ""
     if assignee:
         description = f"Assigned to: {assignee}\n{description}".strip()
+    return description
+
+
+def _best_task_start(task: DonetickTask) -> Optional[datetime | date]:
+    """Return the best start time for an active/scheduled task."""
+    if task.status in (CHORE_STATUS_IN_PROGRESS, CHORE_STATUS_PAUSED):
+        return task.start_time or task.timer_updated_at or task.updated_at or task.next_due_date
+
+    return task.next_due_date
+
+
+def _event_end(start: datetime | date, duration: timedelta) -> datetime | date:
+    """Return a calendar end value matching the start value type."""
+    if not isinstance(start, datetime) and duration < timedelta(days=1):
+        return start + timedelta(days=1)
+    return start + duration
+
+
+def _comparison_datetime(value: datetime | date) -> datetime:
+    """Normalize date/datetime values for internal comparisons."""
+    if not isinstance(value, datetime):
+        return datetime.combine(value, datetime.min.time())
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def _event_sort_key(event: CalendarEvent) -> datetime:
+    """Normalize event starts so date and datetime events sort together."""
+    return _comparison_datetime(event.start)
+
+
+def _event_in_range(event: CalendarEvent, range_start: datetime, range_end: datetime) -> bool:
+    """Return true when a calendar event intersects the requested range."""
+    start = _event_sort_key(event)
+    end = _comparison_datetime(event.end)
+    return start < _comparison_datetime(range_end) and end > _comparison_datetime(range_start)
+
+
+def _task_to_event(task: DonetickTask, members: List[DonetickMember]) -> Optional[CalendarEvent]:
+    """Convert a DonetickTask to a CalendarEvent using the best available time."""
+    start = _best_task_start(task)
+    if start is None:
+        return None
+
+    duration = (
+        DEFAULT_LOGGED_DURATION
+        if task.status in (CHORE_STATUS_IN_PROGRESS, CHORE_STATUS_PAUSED)
+        else DEFAULT_SCHEDULED_DURATION
+    )
 
     return CalendarEvent(
         summary=task.name,
-        start=due,
-        end=due + timedelta(days=1),
-        description=description,
+        start=start,
+        end=_event_end(start, duration),
+        description=_task_description(task, members),
         uid=f"donetick_{task.id}",
     )
 
@@ -64,70 +127,78 @@ def _task_to_event(task: DonetickTask, members: List[DonetickMember]) -> Optiona
 def _generate_occurrences(
     task: DonetickTask,
     members: List[DonetickMember],
-    range_start: date,
-    range_end: date,
+    range_start: datetime,
+    range_end: datetime,
 ) -> List[CalendarEvent]:
     """Generate calendar events for a task within a date range.
 
     For non-recurring tasks, returns the single event if it falls in range.
     For recurring tasks, projects future occurrences based on frequency_type and frequency.
     """
-    if task.next_due_date is None:
+    anchor = _best_task_start(task)
+    if anchor is None:
         return []
 
-    anchor = task.next_due_date.date() if isinstance(task.next_due_date, datetime) else task.next_due_date
-
-    assignee = _get_member_name(members, task.assigned_to)
-    description = task.description or ""
-    if assignee:
-        description = f"Assigned to: {assignee}\n{description}".strip()
+    description = _task_description(task, members)
+    event_duration = (
+        DEFAULT_LOGGED_DURATION
+        if task.status in (CHORE_STATUS_IN_PROGRESS, CHORE_STATUS_PAUSED)
+        else DEFAULT_SCHEDULED_DURATION
+    )
 
     # Non-recurring: single event
     if task.frequency_type not in RECURRING_FREQUENCY_TYPES:
-        if range_start <= anchor < range_end:
-            return [CalendarEvent(
-                summary=task.name,
-                start=anchor,
-                end=anchor + timedelta(days=1),
-                description=description,
-                uid=f"donetick_{task.id}",
-            )]
+        event = CalendarEvent(
+            summary=task.name,
+            start=anchor,
+            end=_event_end(anchor, event_duration),
+            description=description,
+            uid=f"donetick_{task.id}",
+        )
+        if _event_in_range(event, range_start, range_end):
+            return [event]
         return []
 
     # Recurring: compute the interval as a timedelta
     delta = _frequency_to_delta(task.frequency_type, task.frequency)
     if delta is None:
-        # Unsupported frequency — just show the next due date
-        if range_start <= anchor < range_end:
-            return [CalendarEvent(
-                summary=task.name,
-                start=anchor,
-                end=anchor + timedelta(days=1),
-                description=description,
-                uid=f"donetick_{task.id}",
-            )]
+        # Unsupported frequency, just show the next due date.
+        event = CalendarEvent(
+            summary=task.name,
+            start=anchor,
+            end=_event_end(anchor, event_duration),
+            description=description,
+            uid=f"donetick_{task.id}",
+        )
+        if _event_in_range(event, range_start, range_end):
+            return [event]
         return []
 
     events: List[CalendarEvent] = []
     current = anchor
+    current_key = _comparison_datetime(current)
+    range_start_key = _comparison_datetime(range_start)
+    range_end_key = _comparison_datetime(range_end)
 
-    # Walk backwards to find occurrences before anchor but still in range
-    if current > range_start and delta.days > 0:
-        while current - delta >= range_start:
+    # Walk backwards to find occurrences before anchor but still in range.
+    if current_key > range_start_key and delta.total_seconds() > 0:
+        while current_key - delta >= range_start_key:
             current = current - delta
+            current_key = current_key - delta
 
-    # Walk forward through the range
-    while current < range_end:
-        if current >= range_start:
-            events.append(CalendarEvent(
-                summary=task.name,
-                start=current,
-                end=current + timedelta(days=1),
-                description=description,
-                uid=f"donetick_{task.id}_{current.isoformat()}",
-            ))
+    # Walk forward through the range.
+    while current_key < range_end_key:
+        event = CalendarEvent(
+            summary=task.name,
+            start=current,
+            end=_event_end(current, event_duration),
+            description=description,
+            uid=f"donetick_{task.id}_{current.isoformat()}",
+        )
+        if _event_in_range(event, range_start, range_end):
+            events.append(event)
         current = current + delta
-        # Safety: cap at 365 events
+        current_key = current_key + delta
         if len(events) >= 365:
             break
 
@@ -145,8 +216,60 @@ def _frequency_to_delta(frequency_type: str, frequency: int) -> Optional[timedel
         return timedelta(days=30 * freq)
     if frequency_type == "yearly":
         return timedelta(days=365 * freq)
-    # adaptive and others — can't reliably predict
+    # Adaptive and others cannot be reliably predicted.
     return None
+
+
+def _history_to_event(
+    history: DonetickChoreHistory,
+    tasks_by_id: dict[int, DonetickTask],
+    members: List[DonetickMember],
+) -> Optional[CalendarEvent]:
+    """Convert a chore history row to a timed calendar event."""
+    end = history.end_time or history.performed_at or history.updated_at or history.created_at
+    if end is None:
+        return None
+
+    if history.start_time:
+        start = history.start_time
+    elif history.duration and history.duration > 0:
+        start = end - timedelta(seconds=history.duration)
+    else:
+        start = end
+
+    if history.end_time:
+        event_end = history.end_time
+    elif history.duration and history.duration > 0:
+        event_end = end
+    else:
+        event_end = start + DEFAULT_LOGGED_DURATION
+
+    if _comparison_datetime(event_end) <= _comparison_datetime(start):
+        event_end = start + DEFAULT_LOGGED_DURATION
+
+    task = tasks_by_id.get(history.chore_id)
+    task_name = task.name if task else f"Donetick chore {history.chore_id}"
+    status_label = HISTORY_STATUS_LABELS.get(history.status, "Logged")
+    completed_by = _get_member_name(members, history.completed_by) or history.completed_by
+    assigned_to = _get_member_name(members, history.assigned_to) or history.assigned_to
+
+    description_parts = []
+    if completed_by:
+        description_parts.append(f"{status_label} by: {completed_by}")
+    if assigned_to:
+        description_parts.append(f"Assigned to: {assigned_to}")
+    if history.due_date:
+        description_parts.append(f"Due: {history.due_date.isoformat()}")
+    if history.notes:
+        description_parts.append(history.notes)
+
+    return CalendarEvent(
+        summary=f"{status_label}: {task_name}",
+        start=start,
+        end=event_end,
+        description="\n".join(description_parts),
+        uid=f"donetick_history_{history.id}",
+    )
 
 
 async def async_setup_entry(
@@ -157,9 +280,10 @@ async def async_setup_entry(
     """Set up Donetick calendar from a config entry."""
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
+    client = data["client"]
     circle_members = data.get("circle_members", [])
 
-    async_add_entities([DonetickCalendar(coordinator, circle_members, entry)])
+    async_add_entities([DonetickCalendar(coordinator, client, circle_members, entry)])
 
 
 class DonetickCalendar(CoordinatorEntity, CalendarEntity):
@@ -171,11 +295,13 @@ class DonetickCalendar(CoordinatorEntity, CalendarEntity):
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
+        client: DonetickApiClient,
         circle_members: List[DonetickMember],
         entry: ConfigEntry,
     ) -> None:
         """Initialize the calendar."""
         super().__init__(coordinator)
+        self._client = client
         self._circle_members = circle_members
         self._attr_unique_id = f"{entry.entry_id}_calendar"
         self._attr_device_info = {
@@ -190,15 +316,20 @@ class DonetickCalendar(CoordinatorEntity, CalendarEntity):
         tasks: List[DonetickTask] = self.coordinator.data or []
         today = date.today()
         closest_event: Optional[CalendarEvent] = None
-        closest_date: Optional[date] = None
+        closest_date: Optional[datetime] = None
 
         for task in tasks:
-            if not task.is_active or task.next_due_date is None:
+            if not task.is_active:
                 continue
-            due = task.next_due_date.date() if isinstance(task.next_due_date, datetime) else task.next_due_date
-            if closest_date is None or due < closest_date:
-                closest_date = due
-                closest_event = _task_to_event(task, self._circle_members)
+            event = _task_to_event(task, self._circle_members)
+            if event is None:
+                continue
+            event_start = _event_sort_key(event)
+            if event_start.date() < today:
+                continue
+            if closest_date is None or event_start < closest_date:
+                closest_date = event_start
+                closest_event = event
 
         return closest_event
 
@@ -210,16 +341,46 @@ class DonetickCalendar(CoordinatorEntity, CalendarEntity):
     ) -> List[CalendarEvent]:
         """Return events within a date range (called by the calendar card)."""
         tasks: List[DonetickTask] = self.coordinator.data or []
-        range_start = start_date.date() if isinstance(start_date, datetime) else start_date
-        range_end = end_date.date() if isinstance(end_date, datetime) else end_date
+        range_start = (
+            start_date
+            if isinstance(start_date, datetime)
+            else datetime.combine(start_date, datetime.min.time())
+        )
+        range_end = (
+            end_date
+            if isinstance(end_date, datetime)
+            else datetime.combine(end_date, datetime.min.time())
+        )
+        tasks_by_id = {task.id: task for task in tasks}
 
         events: List[CalendarEvent] = []
         for task in tasks:
             if not task.is_active:
                 continue
+            if task.status in (CHORE_STATUS_IN_PROGRESS, CHORE_STATUS_PAUSED) and task.start_time is None:
+                detail = await self._client.async_get_task_detail(task.id)
+                if detail is not None:
+                    task.start_time = detail.start_time
+                    task.timer_updated_at = detail.timer_updated_at
+                    task.duration = detail.duration
             events.extend(
                 _generate_occurrences(task, self._circle_members, range_start, range_end)
             )
 
-        events.sort(key=lambda e: e.start)
+        now = datetime.now(timezone.utc)
+        range_start_key = _comparison_datetime(range_start)
+        range_end_key = _comparison_datetime(range_end)
+        now_key = _comparison_datetime(now)
+        if range_start_key <= now_key and (range_end_key - range_start_key).days <= HISTORY_LOOKBACK_DAYS:
+            history_days = max((now_key - range_start_key).days + 1, 1)
+            histories = await self._client.async_get_task_history(
+                min(history_days, HISTORY_LOOKBACK_DAYS),
+                include_members=True,
+            )
+            for history in histories:
+                event = _history_to_event(history, tasks_by_id, self._circle_members)
+                if event is not None and _event_in_range(event, range_start, range_end):
+                    events.append(event)
+
+        events.sort(key=_event_sort_key)
         return events

--- a/custom_components/donetick/calendar.py
+++ b/custom_components/donetick/calendar.py
@@ -157,8 +157,17 @@ def _is_date_only_due(value: datetime) -> bool:
         (0, 0, 0, 0),
         (23, 59, 0, 0),
         (23, 59, 59, 0),
+        (23, 59, 59, 999000),
         (23, 59, 59, 999999),
     }
+
+
+def _task_has_due_time(task: DonetickTask) -> bool:
+    """Return true only when Donetick reports an explicit scheduled time."""
+    if _metadata_dict(task) or task.frequency_type in RECURRING_FREQUENCY_TYPES:
+        return _metadata_time(task) is not None
+
+    return task.next_due_date is not None and not _is_date_only_due(task.next_due_date)
 
 
 def _best_task_start(task: DonetickTask) -> Optional[datetime | date]:
@@ -169,7 +178,7 @@ def _best_task_start(task: DonetickTask) -> Optional[datetime | date]:
     if task.next_due_date is None:
         return None
 
-    if _is_date_only_due(task.next_due_date):
+    if not _task_has_due_time(task):
         return task.next_due_date.date()
 
     return task.next_due_date
@@ -226,9 +235,9 @@ def _task_to_event(task: DonetickTask, members: List[DonetickMember]) -> Optiona
 
 def _normalize_occurrence_start(task: DonetickTask, due_value: datetime) -> datetime | date:
     """Normalize a due datetime to the display start used by the calendar."""
-    if _is_date_only_due(due_value):
-        return due_value.date()
-    return due_value
+    if _task_has_due_time(task):
+        return due_value
+    return due_value.date()
 
 
 def _scheduled_task_event(

--- a/custom_components/donetick/model.py
+++ b/custom_components/donetick/model.py
@@ -2,7 +2,7 @@
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, List
+from typing import Any, Optional, List
 from homeassistant.components.todo import (
     TodoItem,
     TodoItemStatus,
@@ -11,6 +11,22 @@ from homeassistant.components.todo import (
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    """Parse a Donetick timestamp, returning None for empty or invalid values."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value:
+        return None
+
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        _LOGGER.debug("Unable to parse Donetick datetime: %s", value)
+        return None
 
 @dataclass
 class DonetickMember:
@@ -64,13 +80,20 @@ class DonetickTask:
     next_due_date: Optional[datetime]
     status: int
     priority: int
-    labels: Optional[str]
+    labels: Optional[Any]
     is_active: bool
     frequency_type: str
     frequency: int
-    frequency_metadata: str
+    frequency_metadata: Optional[Any]
     assigned_to: Optional[int] = None
     description: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    last_completed_date: Optional[datetime] = None
+    last_completed_by: Optional[int] = None
+    duration: Optional[int] = None
+    start_time: Optional[datetime] = None
+    timer_updated_at: Optional[datetime] = None
     
     @classmethod
     def from_json(cls, data: dict) -> "DonetickTask":
@@ -84,22 +107,73 @@ class DonetickTask:
         return cls(
             id=data["id"],
             name=data["name"],
-            next_due_date=datetime.fromisoformat(data["nextDueDate"].replace('Z', '+00:00')) if data.get("nextDueDate") else None,
-            status=data["status"],
-            priority=data["priority"],
-            labels=data["labels"],
-            is_active=data["isActive"],
-            frequency_type=data["frequencyType"],
-            frequency=data["frequency"],
-            frequency_metadata=data["frequencyMetadata"],
+            next_due_date=_parse_datetime(data.get("nextDueDate")),
+            status=data.get("status", 0),
+            priority=data.get("priority", 0),
+            labels=data.get("labels") or data.get("labelsV2"),
+            is_active=data.get("isActive", True),
+            frequency_type=data.get("frequencyType", "once"),
+            frequency=data.get("frequency") or 1,
+            frequency_metadata=data.get("frequencyMetadata"),
             assigned_to=assigned_to,
-            description=data.get("description")
+            description=data.get("description"),
+            created_at=_parse_datetime(data.get("createdAt")),
+            updated_at=_parse_datetime(data.get("updatedAt")),
+            last_completed_date=_parse_datetime(data.get("lastCompletedDate")),
+            last_completed_by=data.get("lastCompletedBy"),
+            duration=data.get("duration"),
+            start_time=_parse_datetime(data.get("startTime")),
+            timer_updated_at=_parse_datetime(data.get("timerUpdatedAt")),
         )
     
     @classmethod
     def from_json_list(cls, data: List[dict]) -> List["DonetickTask"]:
         """Create a list of DonetickTasks from JSON data."""
         return [cls.from_json(task) for task in data]
+
+
+@dataclass
+class DonetickChoreHistory:
+    """Donetick chore history model."""
+    id: int
+    chore_id: int
+    performed_at: Optional[datetime]
+    completed_by: Optional[int]
+    assigned_to: Optional[int]
+    due_date: Optional[datetime]
+    status: int
+    notes: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    duration: Optional[int] = None
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+    timer_updated_at: Optional[datetime] = None
+
+    @classmethod
+    def from_json(cls, data: dict) -> "DonetickChoreHistory":
+        """Create a DonetickChoreHistory from JSON data."""
+        return cls(
+            id=data["id"],
+            chore_id=data["choreId"],
+            performed_at=_parse_datetime(data.get("performedAt")),
+            completed_by=data.get("completedBy"),
+            assigned_to=data.get("assignedTo"),
+            due_date=_parse_datetime(data.get("dueDate")),
+            status=data.get("status", 0),
+            notes=data.get("notes"),
+            created_at=_parse_datetime(data.get("createdAt")),
+            updated_at=_parse_datetime(data.get("updatedAt")),
+            duration=data.get("duration"),
+            start_time=_parse_datetime(data.get("startTime")),
+            end_time=_parse_datetime(data.get("endTime")),
+            timer_updated_at=_parse_datetime(data.get("timerUpdatedAt")),
+        )
+
+    @classmethod
+    def from_json_list(cls, data: List[dict]) -> List["DonetickChoreHistory"]:
+        """Create a list of DonetickChoreHistory objects from JSON data."""
+        return [cls.from_json(history) for history in data]
 
 @dataclass 
 class DonetickThing:

--- a/custom_components/donetick/model.py
+++ b/custom_components/donetick/model.py
@@ -82,6 +82,7 @@ class DonetickTask:
     priority: int
     labels: Optional[Any]
     is_active: bool
+    is_rolling: bool
     frequency_type: str
     frequency: int
     frequency_metadata: Optional[Any]
@@ -112,6 +113,7 @@ class DonetickTask:
             priority=data.get("priority", 0),
             labels=data.get("labels") or data.get("labelsV2"),
             is_active=data.get("isActive", True),
+            is_rolling=data.get("isRolling", False),
             frequency_type=data.get("frequencyType", "once"),
             frequency=data.get("frequency") or 1,
             frequency_metadata=data.get("frequencyMetadata"),


### PR DESCRIPTION
## Summary

This PR improves the Donetick calendar integration by making scheduled chores render more accurately in Home Assistant and by separating scheduled chores from completed activity history.

It also fixes [[#43](https://github.com/donetick/donetick-hass-integration/issues/43)], where chores with a due date but no real scheduled time could appear with incorrect timing, and where some chores with valid due times were still being treated as all-day events.

## Changes

- improve recurrence projection for scheduled chores
- separate scheduled chores from completed activity history (2 calendars instead of 1)
- improved support for recurring chores
- improve due-time detection so timed chores render as timed events and date-only chores stay all-day

## Result

The calendar now better reflects how chores are configured in Donetick, especially for recurring chores and chores with explicit due times. The calendar has been split into 2 separate ones, to separate the task log from the scheduled tasks. 
<img width="749" height="458" alt="image" src="https://github.com/user-attachments/assets/738c43a4-b532-4002-9603-ab212e0bd4c6" />
<img width="692" height="483" alt="image" src="https://github.com/user-attachments/assets/0ffbb857-4504-455b-bdb3-2cb9918ab917" />

This allows a nice overview, if the user wants to keep the calendars together HA would also just allow both active at the same time.

